### PR TITLE
silence browser console warnings

### DIFF
--- a/frontend/app.html
+++ b/frontend/app.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fantasy Sports Optimizer</title>
+    <link rel="icon" href='data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">🏀</text></svg>'>
     <link rel = 'stylesheet' href = 'styles/styles.css'>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/frontend/custom_select.ts
+++ b/frontend/custom_select.ts
@@ -9,10 +9,15 @@
 //   container.append(sel.element)
 //   sel.element.addEventListener('change', () => console.log(sel.getValue()))
 //
-// Getter compatibility: a hidden <input id={id}> is kept in sync so that
+// Getter compatibility: a hidden <select id={id}> is kept in sync so that
 // existing getter code like:
 //   (document.getElementById('my-id') as HTMLSelectElement).value
 // continues to work without modification.
+//
+// <select> is used (rather than <input type="hidden">) because a sibling
+// <label for={id}> requires a labelable element per the HTML spec, and
+// <input type="hidden"> is explicitly excluded from that list. Using <select>
+// silences Chrome's "label's for attribute doesn't match any element id" warning.
 
 export interface CustomSelectOption {
     value: string
@@ -29,14 +34,15 @@ export interface CustomSelect {
 /**
  * Creates a fully browser-rendered custom select widget.
  *
- * A `<input type="hidden" id={id}>` is kept in sync inside the wrapper so that
- * existing getter code like `(document.getElementById(id) as HTMLInputElement).value`
- * continues to work without modification.
+ * A `<select id={id} hidden>` is kept in sync inside the wrapper so that
+ * existing getter code like `(document.getElementById(id) as HTMLSelectElement).value`
+ * continues to work without modification, and so that a sibling `<label for={id}>`
+ * references a labelable element (which <input type="hidden"> is not).
  *
  * The wrapper element dispatches a native `'change'` event (bubbling) whenever the
  * selected value changes, so `element.addEventListener('change', cb)` works as expected.
  *
- * @param id           - DOM id; also used for the hidden input that exposes `.value`
+ * @param id           - DOM id; also used for the hidden <select> that exposes `.value`
  * @param options      - Initial option list
  * @param defaultValue - Initially selected value; falls back to `options[0]` if omitted
  */
@@ -56,10 +62,22 @@ export function makeCustomSelect(
     const wrapper = document.createElement('div')
     wrapper.className = 'cs-wrapper'
 
-    // Hidden input — keeps (document.getElementById(id) as HTMLSelectElement).value working.
-    const hiddenInput = document.createElement('input')
-    hiddenInput.type = 'hidden'
-    hiddenInput.id   = id
+    // Hidden <select> — exposes the current value via (document.getElementById(id) as HTMLSelectElement).value,
+    // and gives a sibling <label for={id}> a labelable target so Chrome doesn't warn.
+    const hiddenSelect = document.createElement('select')
+    hiddenSelect.id = id
+    hiddenSelect.hidden = true
+    hiddenSelect.tabIndex = -1
+
+    function syncHiddenSelectOptions(opts: CustomSelectOption[]): void {
+        hiddenSelect.replaceChildren(...opts.map(o => {
+            const optionEl = document.createElement('option')
+            optionEl.value = o.value
+            optionEl.textContent = o.label
+            return optionEl
+        }))
+    }
+    syncHiddenSelectOptions(currentOptions)
 
     // Visible trigger
     const trigger = document.createElement('div')
@@ -67,6 +85,7 @@ export function makeCustomSelect(
 
     const searchInput = document.createElement('input')
     searchInput.type      = 'text'
+    searchInput.name      = `${id}-search`
     searchInput.className = 'cs-search-input'
     searchInput.autocomplete = 'off'
     searchInput.spellcheck   = false
@@ -82,7 +101,7 @@ export function makeCustomSelect(
     dropdown.className = 'cs-dropdown'
     dropdown.hidden = true
 
-    wrapper.append(hiddenInput, trigger, dropdown)
+    wrapper.append(hiddenSelect, trigger, dropdown)
 
     // ── Internal helpers ───────────────────────────────────────────────────
 
@@ -91,9 +110,9 @@ export function makeCustomSelect(
     }
 
     function commit(value: string, silent = false): void {
-        currentValue      = value
-        hiddenInput.value = value
-        searchInput.value = getLabelFor(value)
+        currentValue       = value
+        hiddenSelect.value = value
+        searchInput.value  = getLabelFor(value)
         if (!silent) wrapper.dispatchEvent(new Event('change', { bubbles: true }))
     }
 
@@ -207,6 +226,7 @@ export function makeCustomSelect(
 
     function setOptions(opts: CustomSelectOption[], preferredValue?: string): void {
         currentOptions = [...opts]
+        syncHiddenSelectOptions(currentOptions)
         const keep = preferredValue ?? currentValue
         const resolved = currentOptions.find(o => o.value === keep)?.value
                       ?? currentOptions[0]?.value ?? ''

--- a/frontend/helper_functions.ts
+++ b/frontend/helper_functions.ts
@@ -131,6 +131,7 @@ export function renderMultiselect(
 
     const textInput = document.createElement('input')
     textInput.type = 'text'
+    textInput.name = 'multiselect-search'
     textInput.className = 'ms-input'
     textInput.placeholder = 'Add…'
     textInput.autocomplete = 'off'

--- a/frontend/parameter_collection/league_settings.ts
+++ b/frontend/parameter_collection/league_settings.ts
@@ -111,7 +111,7 @@ export function renderLeagueSettings(container: HTMLElement): void {
     // readers (draft_board, season modules, main.ts) continue to work.
     // The visible UI is a scrollable list of rows: [editable name] [mode ▼]
     const teamNamesWrap = document.createElement('div')
-    teamNamesWrap.append(makeLabel('ls-team-names-label', 'Teams'))
+    teamNamesWrap.append(makeLabel('ls-team-names', 'Teams'))
 
     const hiddenNamesTextarea = document.createElement('textarea')
     hiddenNamesTextarea.id    = 'ls-team-names'


### PR DESCRIPTION
- custom_select: store value in a hidden <select> (labelable) instead of <input type="hidden"> (not labelable per spec) so sibling <label for> references resolve, plus add a name to the search input
- helper_functions: add a name to the multiselect search input
- league_settings: fix label for on the Teams field (ls-team-names-label -> ls-team-names)
- app.html: inline SVG basketball emoji favicon to avoid 404 on /favicon.ico