### PR TITLE
refactor table builders and api session handling

### DIFF
--- a/frontend/api/client.ts
+++ b/frontend/api/client.ts
@@ -10,6 +10,40 @@ import { PlayerResult, PlayerGScore, SessionRequest, SportConfig } from '../type
 // and backend are ever deployed on different origins.
 export const BASE_URL = ''
 
+
+// ── HTTP helpers ──────────────────────────────────────────────────────────────
+
+/** Thrown by jsonRequest when the backend returns a non-2xx status. Callers that
+ *  want to react to specific statuses (e.g. retry on session expiry) should catch
+ *  this and check `.status` rather than parsing the message string. */
+export class HTTPError extends Error {
+    constructor(
+        public readonly status: number
+        , public readonly body: string
+        , label: string
+    ) {
+        super(`${label} failed (${status}): ${body}`)
+        this.name = 'HTTPError'
+    }
+}
+
+/** Issues `fetch(url, init)` and parses the JSON response, throwing HTTPError on
+ *  non-2xx. The `label` prefixes error messages so callers don't each repeat the
+ *  "X failed (status): body" boilerplate. */
+async function jsonRequest<T>(
+    url: string
+    , label: string
+    , init?: RequestInit
+): Promise<T> {
+    const res = await fetch(url, init)
+    if (!res.ok) {
+        const body = await res.text()
+        throw new HTTPError(res.status, body, label)
+    }
+    return res.json() as Promise<T>
+}
+
+
 // ── Map backend Candidate → frontend PlayerResult ─────────────────────────────
 
 
@@ -61,12 +95,7 @@ export function candidatesToPlayerResults(candidates: any[]): PlayerResult[] {
 
 /** Fetches sport-specific configuration (defaults, categories, positions) from parameters.yaml. */
 export async function fetchConfig(sport: string): Promise<SportConfig> {
-    const res = await fetch(`${BASE_URL}/config/${encodeURIComponent(sport)}`)
-    if (!res.ok) {
-        const detail = await res.text()
-        throw new Error(`Config fetch failed (${res.status}): ${detail}`)
-    }
-    return res.json()
+    return jsonRequest(`${BASE_URL}/config/${encodeURIComponent(sport)}`, 'Config fetch')
 }
 
 // ── POST /data/upload ─────────────────────────────────────────────────────────
@@ -79,25 +108,15 @@ export async function uploadCsv(
     const form = new FormData()
     form.append('file', file)
     form.append('file_type', fileType)
-    const res = await fetch(`${BASE_URL}/data/upload`, { method: 'POST', body: form })
-    if (!res.ok) {
-        const detail = await res.text()
-        throw new Error(`Upload failed (${res.status}): ${detail}`)
-    }
-    return res.json()
+    return jsonRequest(`${BASE_URL}/data/upload`, 'Upload', { method: 'POST', body: form })
 }
 
 // ── GET /seasons ───────────────────────────────────────────────────────────────
 
 /** Fetches the list of available historical seasons from the backend. */
 export async function getSeasons(): Promise<string[]> {
-    const res = await fetch(`${BASE_URL}/seasons`)
-    if (!res.ok) {
-        const detail = await res.text()
-        throw new Error(`Get seasons failed (${res.status}): ${detail}`)
-    }
-    const data = await res.json()
-    return data.seasons as string[]
+    const data = await jsonRequest<{ seasons: string[] }>(`${BASE_URL}/seasons`, 'Get seasons')
+    return data.seasons
 }
 
 // ── POST /sessions ─────────────────────────────────────────────────────────────
@@ -107,17 +126,12 @@ export async function createSession(
     req: SessionRequest,
     signal?: AbortSignal,
 ): Promise<{ session_id: string; categories: string[]; g_scores: PlayerGScore[]; n_players_loaded: number; expires_at: string }> {
-    const res = await fetch(`${BASE_URL}/sessions`, {
+    return jsonRequest(`${BASE_URL}/sessions`, 'Create session', {
         method:  'POST',
         headers: { 'Content-Type': 'application/json' },
         body:    JSON.stringify(req),
         signal,
     })
-    if (!res.ok) {
-        const detail = await res.text()
-        throw new Error(`Create session failed (${res.status}): ${detail}`)
-    }
-    return res.json()
 }
 
 // ── PATCH /sessions/{id} ──────────────────────────────────────────────────────
@@ -128,30 +142,20 @@ export async function patchSession(
     req: Record<string, unknown>,
     signal?: AbortSignal,
 ): Promise<{ ok: boolean; steps_rerun: number[] }> {
-    const res = await fetch(`${BASE_URL}/sessions/${sessionId}`, {
+    return jsonRequest(`${BASE_URL}/sessions/${sessionId}`, 'Patch session', {
         method:  'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body:    JSON.stringify(req),
         signal,
     })
-    if (!res.ok) {
-        const detail = await res.text()
-        throw new Error(`Patch session failed (${res.status}): ${detail}`)
-    }
-    return res.json()
 }
 
 // ── GET /sessions/{id}/g-scores ───────────────────────────────────────────────
 
 /** Fetches the current G-scores for a session directly from session state. */
 export async function fetchGScores(sessionId: string): Promise<PlayerGScore[]> {
-    const res = await fetch(`${BASE_URL}/sessions/${sessionId}/g-scores`)
-    if (!res.ok) {
-        const detail = await res.text()
-        throw new Error(`Fetch G-scores failed (${res.status}): ${detail}`)
-    }
-    const data = await res.json()
-    return data.g_scores as PlayerGScore[]
+    const data = await jsonRequest<{ g_scores: PlayerGScore[] }>(`${BASE_URL}/sessions/${sessionId}/g-scores`, 'Fetch G-scores')
+    return data.g_scores
 }
 
 // ── POST /sessions/{id}/evaluate ──────────────────────────────────────────────
@@ -168,17 +172,12 @@ export async function evaluate(
     signal?: AbortSignal,
 ): Promise<{ iteration: number; candidates: any[] }> {
     const body = { exclusion_list: [], ...req }
-    const res = await fetch(`${BASE_URL}/sessions/${sessionId}/evaluate`, {
+    return jsonRequest(`${BASE_URL}/sessions/${sessionId}/evaluate`, 'Evaluate', {
         method:  'POST',
         headers: { 'Content-Type': 'application/json' },
         body:    JSON.stringify(body),
         signal,
     })
-    if (!res.ok) {
-        const detail = await res.text()
-        throw new Error(`Evaluate failed (${res.status}): ${detail}`)
-    }
-    return res.json()
 }
 
 // ── POST /sessions/{id}/trade/analyze ────────────────────────────────────────
@@ -211,16 +210,11 @@ export async function analyzeTrade(
         ignore_position_check?: boolean
     },
 ): Promise<TradeAnalyzeResponse> {
-    const res = await fetch(`${BASE_URL}/sessions/${sessionId}/trade/analyze`, {
+    return jsonRequest(`${BASE_URL}/sessions/${sessionId}/trade/analyze`, 'Trade analyze', {
         method:  'POST',
         headers: { 'Content-Type': 'application/json' },
         body:    JSON.stringify(req),
     })
-    if (!res.ok) {
-        const detail = await res.text()
-        throw new Error(`Trade analyze failed (${res.status}): ${detail}`)
-    }
-    return res.json()
 }
 
 // ── POST /sessions/{id}/trade/suggest ────────────────────────────────────────
@@ -249,14 +243,9 @@ export async function suggestTrades(
         ignore_position_check?: boolean
     },
 ): Promise<TradeSuggestResponse> {
-    const res = await fetch(`${BASE_URL}/sessions/${sessionId}/trade/suggest`, {
+    return jsonRequest(`${BASE_URL}/sessions/${sessionId}/trade/suggest`, 'Trade suggest', {
         method:  'POST',
         headers: { 'Content-Type': 'application/json' },
         body:    JSON.stringify(req),
     })
-    if (!res.ok) {
-        const detail = await res.text()
-        throw new Error(`Trade suggest failed (${res.status}): ${detail}`)
-    }
-    return res.json()
 }

--- a/frontend/api/draft_and_auction_session.ts
+++ b/frontend/api/draft_and_auction_session.ts
@@ -8,8 +8,8 @@ import { getLeagueSettings } from '../parameter_collection/league_settings.js'
 import { getDraftState } from '../data_entry/draft_state.js'
 import { getAuctionState } from '../data_entry/auction_state.js'
 import { buildTable, showTableMessage } from '../table/player_table.js'
-import { startFreshSession, ensureSession, getSessionId, resetSession, setIndicatorState } from './session.js'
-import { patchSession, fetchGScores, evaluate, candidatesToPlayerResults } from './client.js'
+import { startFreshSession, getSessionId, resetSession, setIndicatorState, withSessionRetry } from './session.js'
+import { patchSession, fetchGScores, evaluate, candidatesToPlayerResults, HTTPError } from './client.js'
 
 // ─── Draft/auction state ─────────────────────────────────────────────────────
 
@@ -51,8 +51,8 @@ export async function createOrPatchSession(
             const freshGScores = await fetchGScores(getSessionId()!)
             setGScores(freshGScores)
         }
-    } catch (err: any) {
-        if (!err.message?.includes('(404)')) throw err
+    } catch (err) {
+        if (!(err instanceof HTTPError) || err.status !== 404) throw err
         resetSession()
         await startFreshSession(signal)
     }
@@ -73,71 +73,61 @@ async function evaluateSeat(seat: string): Promise<void> {
     setIndicatorState('evaluating')
 
     try {
-        for (let attempt = 0; attempt < 2; attempt++) {
-            try {
-                await ensureSession()
-                setIndicatorState('evaluating')
+        await withSessionRetry(async () => {
+            const mode = (document.getElementById('ls-mode') as HTMLInputElement).value
 
-                const mode = (document.getElementById('ls-mode') as HTMLInputElement).value
-
-                let evalReq: Parameters<typeof evaluate>[1]
-                if (mode === 'Auction Mode') {
-                    const { player_assignments, remaining_cash } = getAuctionState()
-                    evalReq = { player_assignments, my_team_id: seat, remaining_cash }
-                } else {
-                    const { player_assignments } = getDraftState()
-                    evalReq = { player_assignments, my_team_id: seat }
-                }
-
-                const boardIsEmpty = Object.values(evalReq.player_assignments).flat().length === 0
-                if (!basePlayersBySession.has(getSessionId()!) && !boardIsEmpty) {
-                    const { n_drafters } = getLeagueSettings()
-                    const genericTeams   = Array.from({ length: n_drafters }, (_, i) => `Team ${i + 1}`)
-                    const emptyAssignments: Record<string, string[]> = Object.fromEntries(
-                        genericTeams.map(name => [name, []])
-                    )
-                    const baseResp = await evaluate(
-                        getSessionId()!
-                    ,   { player_assignments: emptyAssignments, my_team_id: genericTeams[0] }
-                    ,   signal
-                    )
-                    basePlayersBySession.set(getSessionId()!, candidatesToPlayerResults(baseResp.candidates))
-                }
-
-                const myTeamSize = (evalReq.player_assignments[seat] ?? []).length
-                if (myTeamSize >= getLeagueSettings().n_picks) {
-                    latestFullTeamResult = null
-                    const fullTeamResp = await evaluate(getSessionId()!, evalReq, signal)
-                    if (fullTeamResp.candidates.length > 0) {
-                        latestFullTeamResult = {
-                            h_score:   fullTeamResp.candidates[0].h_score,
-                            win_rates: fullTeamResp.candidates[0].win_rates,
-                        }
-                        document.dispatchEvent(new Event('full-team-result-updated'))
-                    }
-                    return
-                }
-                latestFullTeamResult = null
-
-                const resp = await evaluate(getSessionId()!, evalReq, signal)
-                const players = candidatesToPlayerResults(resp.candidates)
-
-                if (!basePlayersBySession.has(getSessionId()!)) {
-                    basePlayersBySession.set(getSessionId()!, players)
-                }
-
-                setBasePlayerResults(basePlayersBySession.get(getSessionId()!)!)
-                setCandidatePlayerResults(players)
-                return
-            } catch (err: any) {
-                if (err.name === 'AbortError') return
-                if (attempt === 0 && err.message?.includes('(404)')) {
-                    resetSession()
-                    continue
-                }
-                throw err
+            let evalReq: Parameters<typeof evaluate>[1]
+            if (mode === 'Auction Mode') {
+                const { player_assignments, remaining_cash } = getAuctionState()
+                evalReq = { player_assignments, my_team_id: seat, remaining_cash }
+            } else {
+                const { player_assignments } = getDraftState()
+                evalReq = { player_assignments, my_team_id: seat }
             }
-        }
+
+            const boardIsEmpty = Object.values(evalReq.player_assignments).flat().length === 0
+            if (!basePlayersBySession.has(getSessionId()!) && !boardIsEmpty) {
+                const { n_drafters } = getLeagueSettings()
+                const genericTeams   = Array.from({ length: n_drafters }, (_, i) => `Team ${i + 1}`)
+                const emptyAssignments: Record<string, string[]> = Object.fromEntries(
+                    genericTeams.map(name => [name, []])
+                )
+                const baseResp = await evaluate(
+                    getSessionId()!
+                ,   { player_assignments: emptyAssignments, my_team_id: genericTeams[0] }
+                ,   signal
+                )
+                basePlayersBySession.set(getSessionId()!, candidatesToPlayerResults(baseResp.candidates))
+            }
+
+            const myTeamSize = (evalReq.player_assignments[seat] ?? []).length
+            if (myTeamSize >= getLeagueSettings().n_picks) {
+                latestFullTeamResult = null
+                const fullTeamResp = await evaluate(getSessionId()!, evalReq, signal)
+                if (fullTeamResp.candidates.length > 0) {
+                    latestFullTeamResult = {
+                        h_score:   fullTeamResp.candidates[0].h_score,
+                        win_rates: fullTeamResp.candidates[0].win_rates,
+                    }
+                    document.dispatchEvent(new Event('full-team-result-updated'))
+                }
+                return
+            }
+            latestFullTeamResult = null
+
+            const resp = await evaluate(getSessionId()!, evalReq, signal)
+            const players = candidatesToPlayerResults(resp.candidates)
+
+            if (!basePlayersBySession.has(getSessionId()!)) {
+                basePlayersBySession.set(getSessionId()!, players)
+            }
+
+            setBasePlayerResults(basePlayersBySession.get(getSessionId()!)!)
+            setCandidatePlayerResults(players)
+        })
+    } catch (err: any) {
+        if (err.name === 'AbortError') return
+        throw err
     } finally {
         if (evaluateGeneration === generation) setIndicatorState('idle')
     }
@@ -151,7 +141,7 @@ export async function runEvaluate(): Promise<void> {
         if (getFullTeamResult()) {
             showTableMessage('Your team is full.')
         } else {
-            buildTable(getCandidatePlayerResults())
+            buildTable(getCandidatePlayerResults()!)
         }
     }
 }

--- a/frontend/api/season_session.ts
+++ b/frontend/api/season_session.ts
@@ -5,7 +5,7 @@
 
 import { setCandidatePlayerResults, setPlayerResultsFromGScores } from '../app_state.js'
 import { buildTable } from '../table/player_table.js'
-import { ensureSession, getSessionId, resetSession, setIndicatorState, applyIndicatorState } from './session.js'
+import { ensureSession, getSessionId, setIndicatorState, applyIndicatorState, withSessionRetry } from './session.js'
 import { evaluate, candidatesToPlayerResults, analyzeTrade, suggestTrades } from './client.js'
 import type { TradeAnalyzeResponse, TradeSuggestResponse } from './client.js'
 
@@ -54,26 +54,14 @@ export async function runTradeAnalyze(
   , theirTrade: string[]
   , ignorePositionCheck?: boolean
 ): Promise<TradeAnalyzeResponse> {
-    for (let attempt = 0; attempt < 2; attempt++) {
-        try {
-            await ensureSession()
-            return await analyzeTrade(getSessionId()!, {
-                player_assignments:  playerAssignments,
-                my_team:             myTeam,
-                their_team:          theirTeam,
-                my_trade:            myTrade,
-                their_trade:         theirTrade,
-                ignore_position_check: ignorePositionCheck,
-            })
-        } catch (err: any) {
-            if (attempt === 0 && err.message?.includes('(404)')) {
-                resetSession()
-                continue
-            }
-            throw err
-        }
-    }
-    throw new Error('Trade analyze failed after retry')
+    return await withSessionRetry(() => analyzeTrade(getSessionId()!, {
+        player_assignments:    playerAssignments,
+        my_team:               myTeam,
+        their_team:            theirTeam,
+        my_trade:              myTrade,
+        their_trade:           theirTrade,
+        ignore_position_check: ignorePositionCheck,
+    }))
 }
 
 // ─── Trade suggestions ───────────────────────────────────────────────────────
@@ -93,30 +81,21 @@ export async function runTradeSuggest(
   , theirThreshold: number
   , ignorePositionCheck?: boolean
 ): Promise<TradeSuggestResponse> {
-    applyIndicatorState('suggest-indicator', 'fetching')
-    for (let attempt = 0; attempt < 2; attempt++) {
-        try {
-            await ensureSession()
+    return await withSessionRetry(
+        async () => {
             applyIndicatorState('suggest-indicator', 'evaluating')
             return await suggestTrades(getSessionId()!, {
-                player_assignments:          playerAssignments,
-                my_team:                     myTeam,
-                their_team:                  theirTeam,
-                combo_params:                comboParams,
-                your_differential_threshold: yourThreshold,
+                player_assignments:           playerAssignments,
+                my_team:                      myTeam,
+                their_team:                   theirTeam,
+                combo_params:                 comboParams,
+                your_differential_threshold:  yourThreshold,
                 their_differential_threshold: theirThreshold,
-                ignore_position_check:       ignorePositionCheck,
+                ignore_position_check:        ignorePositionCheck,
             })
-        } catch (err: any) {
-            if (attempt === 0 && err.message?.includes('(404)')) {
-                resetSession()
-                applyIndicatorState('suggest-indicator', 'fetching')
-                continue
-            }
-            throw err
         }
-    }
-    throw new Error('Trade suggest failed after retry')
+        , () => applyIndicatorState('suggest-indicator', 'fetching')
+    )
 }
 
 // ─── Waiver wire ─────────────────────────────────────────────────────────────
@@ -132,22 +111,12 @@ export async function runWaiverEvaluate(
 ): Promise<void> {
     setIndicatorState('evaluating')
     try {
-        for (let attempt = 0; attempt < 2; attempt++) {
-            try {
-                await ensureSession()
-                const resp = await evaluate(getSessionId()!, { player_assignments: playerAssignments, my_team_id: myTeamId })
-                const players = candidatesToPlayerResults(resp.candidates)
-                setCandidatePlayerResults(players)
-                buildTable(players)
-                return
-            } catch (err: any) {
-                if (attempt === 0 && err.message?.includes('(404)')) {
-                    resetSession()
-                    continue
-                }
-                throw err
-            }
-        }
+        await withSessionRetry(async () => {
+            const resp = await evaluate(getSessionId()!, { player_assignments: playerAssignments, my_team_id: myTeamId })
+            const players = candidatesToPlayerResults(resp.candidates)
+            setCandidatePlayerResults(players)
+            buildTable(players)
+        })
     } finally {
         setIndicatorState('idle')
     }

--- a/frontend/api/session.ts
+++ b/frontend/api/session.ts
@@ -9,7 +9,7 @@ import { getScoringFormat, getSelectedCategories, syncCategoriesFromBackend } fr
 import { getPlayerStatsParams } from '../parameter_collection/player_stats.js'
 import { getModelParameters } from '../parameter_collection/model_parameters.js'
 import { getSlotCounts } from '../parameter_collection/slot_counts.js'
-import { createSession } from './client.js'
+import { createSession, HTTPError } from './client.js'
 
 // ─── Module state ─────────────────────────────────────────────────────────────
 
@@ -36,12 +36,12 @@ export function resetSession(): void          { sessionId = null }
 /** Applies a state to any indicator element, looked up by ID. */
 export function applyIndicatorState(
     elementId: string
-    , state: string
+    , state: IndicatorState
 ): void {
     const element = document.getElementById(elementId)
     if (!element) return
     element.dataset.state = state
-    element.textContent = INDICATOR_LABELS[state] ?? ''
+    element.textContent = INDICATOR_LABELS[state]
 }
 
 /** Sets the primary #eval-indicator to fetching, evaluating, or idle.  Suppressed while autopilot is active. */
@@ -97,5 +97,65 @@ export async function startFreshSession(signal?: AbortSignal): Promise<void> {
 export async function ensureSession(): Promise<void> {
     if (sessionId) return
     await startFreshSession()
+}
+
+// ─── Indicator-aware debouncer ────────────────────────────────────────────────
+// Used by draft_board, auction_entry, and the player-stats sidebar so rapid
+// edits only trigger one backend call after `delayMs` of inactivity. Each fire()
+// also flips #eval-indicator to "evaluating" immediately, so the spinner appears
+// as soon as the user acts rather than after the debounce window expires.
+
+export interface Debouncer {
+    /** Schedule the callback; resets the timer on each call. */
+    fire(): void
+    /** Cancel any pending invocation (e.g. on board reset). */
+    cancel(): void
+}
+
+/** Creates a debouncer that calls `fn` only after `delayMs` ms of inactivity.
+ *  Each `fire()` also sets the eval indicator to "evaluating" so the spinner is
+ *  visible during the debounce window; the eventual `fn()` is expected to clear
+ *  it (e.g. via runEvaluate's finally). */
+export function makeDebouncer(fn: () => void, delayMs = 300): Debouncer {
+    let timer: ReturnType<typeof setTimeout> | null = null
+    return {
+        fire() {
+            if (timer) clearTimeout(timer)
+            setIndicatorState('evaluating')
+            timer = setTimeout(() => { timer = null; fn() }, delayMs)
+        },
+        cancel() {
+            if (timer) { clearTimeout(timer); timer = null }
+        },
+    }
+}
+
+// ─── Session retry ────────────────────────────────────────────────────────────
+
+/**
+ * Ensures a session exists, runs `fn`, and retries once with a fresh session if
+ * the backend returns 404 (session expired).  Other errors propagate.
+ *
+ * `onBeforeAttempt` runs before each attempt's ensureSession call — useful for
+ * resetting an indicator back to a "fetching" state for the retry.
+ */
+export async function withSessionRetry<T>(
+    fn: () => Promise<T>
+    , onBeforeAttempt?: () => void
+): Promise<T> {
+    for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+            onBeforeAttempt?.()
+            await ensureSession()
+            return await fn()
+        } catch (err) {
+            if (attempt === 0 && err instanceof HTTPError && err.status === 404) {
+                resetSession()
+                continue
+            }
+            throw err
+        }
+    }
+    throw new Error('withSessionRetry: loop exited without returning')
 }
 

--- a/frontend/data_entry/auction_entry.ts
+++ b/frontend/data_entry/auction_entry.ts
@@ -4,7 +4,7 @@
 
 import { makeCustomSelect } from '../custom_select.js'
 import { getCandidatePlayerResults } from '../app_state.js'
-import { makeDebouncer } from '../helper_functions.js'
+import { makeDebouncer } from '../api/session.js'
 import { runEvaluate } from '../api/draft_and_auction_session.js'
 import {
     AuctionConfig,

--- a/frontend/data_entry/draft_board.ts
+++ b/frontend/data_entry/draft_board.ts
@@ -4,7 +4,7 @@
 
 import { makeCustomSelect } from '../custom_select.js'
 import { getPlayerResults, getCandidatePlayerResults, getPlayerNamesByGScore, getSessionPhase, getCurrentSeat, setCurrentSeat } from '../app_state.js'
-import { makeDebouncer } from '../helper_functions.js'
+import { makeDebouncer } from '../api/session.js'
 import { runEvaluate, clearFullTeamResult } from '../api/draft_and_auction_session.js'
 import { setAutopilotOn, setAutopilotOff } from '../api/session.js'
 import { getDrafterMethodByIndex } from '../parameter_collection/league_settings.js'

--- a/frontend/helper_functions.ts
+++ b/frontend/helper_functions.ts
@@ -23,30 +23,6 @@ document.addEventListener('mouseover', (e: MouseEvent) => {
     _tooltip.style.display = 'block'
 })
 
-// ─── Debounce helper ─────────────────────────────────────────────────────────
-// Used by draft_board and auction_entry so rapid "Lock in" clicks only trigger
-// one backend call after a 300ms pause.
-
-export interface Debouncer {
-    /** Schedule the callback; resets the timer on each call. */
-    fire(): void
-    /** Cancel any pending invocation (e.g. on board reset). */
-    cancel(): void
-}
-
-/** Creates a debouncer that calls `fn` only after `delayMs` ms of inactivity. Each `fire()` resets the timer. */
-export function makeDebouncer(fn: () => void, delayMs = 300): Debouncer {
-    let timer: ReturnType<typeof setTimeout> | null = null
-    return {
-        fire() {
-            if (timer) clearTimeout(timer)
-            timer = setTimeout(() => { timer = null; fn() }, delayMs)
-        },
-        cancel() {
-            if (timer) { clearTimeout(timer); timer = null }
-        },
-    }
-}
 
 /** Creates a `<label>` with class `sidebar-label`, linked to the given input id. */
 export function makeLabel(forId: string, text: string): HTMLLabelElement {

--- a/frontend/main.ts
+++ b/frontend/main.ts
@@ -3,12 +3,13 @@
 // initializes the layout, and triggers the first backend evaluation.
 // All heavy logic lives in api/session.ts, table/player_table.ts, and layout.ts.
 
-import { createSection, addApplyBtn, makeSidebarToggle, makeDebouncer } from './helper_functions.js'
-import { getCandidatePlayerResults, setSportConfig, getCurrentSeat, setCurrentSeat } from './app_state.js'
+import { createSection, addApplyBtn, makeSidebarToggle } from './helper_functions.js'
+import { makeDebouncer } from './api/session.js'
+import { setSportConfig, getCurrentSeat, setCurrentSeat } from './app_state.js'
 import { createOrPatchSession, runEvaluate, clearFullTeamResult } from './api/draft_and_auction_session.js'
 import { runSeasonInit } from './api/season_session.js'
 import { fetchConfig } from './api/client.js'
-import { buildTable } from './table/player_table.js'
+import { buildTableHeader } from './table/player_table.js'
 import { applyLayout } from './layout.js'
 import { resetDraftBoard } from './data_entry/draft_board.js'
 import { resetAuctionEntry } from './data_entry/auction_entry.js'
@@ -74,13 +75,14 @@ if (initialTeamNames.length > 0) {
 seatSelect.element.addEventListener('change', () => {
     setCurrentSeat(seatSelect.getValue() ?? null)
     clearFullTeamResult()
+    buildTableHeader()
     runModeEval()
         .then(() => applyLayout())
         .catch(err => console.error('Seat change evaluate failed:', err))
 })
 
 // Mode change: rebuild table and sync session.
-// Registered before the applyLayout listener so buildTable fires first, ensuring
+// Registered before the applyLayout listener so buildTableHeader fires first, ensuring
 // hscoretable.style.width is correct when applyLayout reads it.
 // When switching to Auction Mode, patch cash_per_team so the backend can compute dollar values.
 // AbortController cancels stale backend calls on rapid mode switches.
@@ -94,7 +96,7 @@ document.getElementById('ls-mode')!.parentElement!.addEventListener('change', ()
 
     if (mode === 'Season Mode') return   // table is hidden in season mode; skip rebuild and backend call
 
-    buildTable(getCandidatePlayerResults())
+    buildTableHeader()
 
     const patch = mode === 'Auction Mode' ? { league: { cash_per_team } } : {}
     createOrPatchSession(4, patch, signal)
@@ -117,7 +119,7 @@ for (const id of ['ls-n-drafters', 'ls-n-picks', 'ls-cash-per-team']) {
         leagueSettingsController = new AbortController()
         const { signal } = leagueSettingsController
 
-        buildTable(getCandidatePlayerResults())
+        buildTableHeader()
         applyLayout()  // re-renders draft board with new n_drafters/n_picks so getDraftState() is current before evaluate
         revalidateSlotCounts()
         if (!isSlotCountsValid()) return
@@ -143,7 +145,7 @@ document.getElementById('ls-team-names')!.addEventListener('input', () => {
             setCurrentSeat(updatedTeamNames[0])
             seatSelect.setValue(updatedTeamNames[0])
         }
-        buildTable(getCandidatePlayerResults())
+        buildTableHeader()
         applyLayout()
     }, 600)
 })
@@ -157,6 +159,7 @@ const applyPlayerStats = (signal?: AbortSignal) => {
     const { data_source, injured_players } = getPlayerStatsParams()
     resetDraftBoard()
     resetAuctionEntry()
+    buildTableHeader()
     createOrPatchSession(1, { data_source, injured_players }, signal)
         .then(() => { if (!signal || !signal.aborted) return runModeEval() })
         .then(() => { if (!signal || !signal.aborted) applyLayout() })
@@ -186,6 +189,7 @@ formatSection.addEventListener('change', () => {
     if (formatController) formatController.abort()
     formatController = new AbortController()
     const { signal } = formatController
+    buildTableHeader()
     createOrPatchSession(4, { league: { scoring_format: getScoringFormat(), categories: getSelectedCategories() } }, signal)
         .then(() => { if (!signal.aborted) return runModeEval() })
         .then(() => { if (!signal.aborted) applyLayout() })
@@ -204,6 +208,7 @@ modelSection.addEventListener('change', () => {
     if (modelController) modelController.abort()
     modelController = new AbortController()
     const { signal } = modelController
+    buildTableHeader()
     createOrPatchSession(3, { parameters: getModelParameters() }, signal)
         .then(() => { if (!signal.aborted) return runModeEval() })
         .then(() => { if (!signal.aborted) applyLayout() })
@@ -220,6 +225,7 @@ renderSlotCounts(slotSection)
 addApplyBtn(slotSection, async () => {
     if (!isSlotCountsValid()) return
     const slot_counts = getSlotCounts()
+    buildTableHeader()
     await createOrPatchSession(4, { slot_counts })
     await runModeEval()
     applyLayout()
@@ -246,7 +252,7 @@ themeInput.addEventListener('change', () => {
 sidebar.style.visibility = ''
 
 applyLayout()
-buildTable(null)
+buildTableHeader()
 waitForInitialSeasons()
     .then(() => runModeEval())
     .then(() => applyLayout())

--- a/frontend/table/expand_view.ts
+++ b/frontend/table/expand_view.ts
@@ -61,28 +61,24 @@ export function toggleExpandView(
             cell.appendChild(makeWeightsTable(playerData, categories))
         }
 
+        // Position-column count shared between the flex allocations and roster
+        // tables so each non-label column has the same width in both. The roster
+        // always includes every base position the flex table can allocate to plus
+        // extra flex types (G, F, Util), so its position-type count is the larger
+        // of the two and the flex table pads with invisible filler columns to match.
+        const nRosterPositionTypes = playerData.roster
+            ? new Set(playerData.roster.slots.map(slot => slot.replace(/\d+$/, ''))).size
+            : 0
+
         if (playerData.flex_allocations) {
             cell.appendChild(makePanelLabel('Position allocations for future flex spot picks', '60px'))
 
-            // Compute a shared per-position column width so base position columns align
-            // between the flex allocations table and the roster grid beneath it.
-            // Size columns using the wider table (roster, which has extra flex-slot columns)
-            // so both tables fit within the available space.
-            const INDENT_W         = 100   // matches .panel-indent margin-left
-            const POSITION_LABEL_W = 110   // matches .panel-colspacer-position-label
-            const containerWidth   = cell.clientWidth
-            const nBasePositions   = playerData.flex_allocations.base_positions.length
-            const nRosterPositionTypes = playerData.roster
-                ? new Set(playerData.roster.slots.map(slot => slot.replace(/\d+$/, ''))).size
-                : nBasePositions
-            const nMaxColumns     = Math.max(nBasePositions, nRosterPositionTypes)
-            const positionColumnWidth = Math.floor((containerWidth - INDENT_W - POSITION_LABEL_W) / nMaxColumns)
-
             if (playerData.auction_values) {
-                // In auction mode, show flex allocations and auction values side-by-side.
+                // Side-by-side with auction values. The flex table keeps its natural
+                // per-column width (no roster filler) so the auction block fits beside it.
                 const sideRow = document.createElement('div')
                 sideRow.className = 'panel-flex-row'
-                sideRow.appendChild(makeFlexAllocationsTable(playerData.flex_allocations, false, positionColumnWidth))
+                sideRow.appendChild(makeFlexAllocationsTable(playerData.flex_allocations, false, playerData.flex_allocations.base_positions.length))
 
                 const auctionBlock = document.createElement('div')
                 auctionBlock.appendChild(makePanelLabel('All auction values'))
@@ -91,31 +87,16 @@ export function toggleExpandView(
 
                 cell.appendChild(sideRow)
             } else {
-                cell.appendChild(makeFlexAllocationsTable(playerData.flex_allocations, true, positionColumnWidth))
-            }
-
-            if (playerData.roster) {
-                cell.appendChild(makePanelLabel('Roster assignments', '60px'))
-                cell.appendChild(makeRosterGrid(playerData.roster, positionColumnWidth))
+                cell.appendChild(makeFlexAllocationsTable(playerData.flex_allocations, true, nRosterPositionTypes))
             }
         } else if (playerData.auction_values) {
-            // No position data but in auction mode: still show auction values alone.
             cell.appendChild(makePanelLabel('All auction values', '60px'))
             cell.appendChild(makeAuctionValuesTable(playerData))
+        }
 
-            if (playerData.roster) {
-                cell.appendChild(makePanelLabel('Roster assignments', '60px'))
-                const INDENT_W         = 100
-                const POSITION_LABEL_W = 110
-                const nRosterPositionTypes = new Set(playerData.roster.slots.map(slot => slot.replace(/\d+$/, ''))).size
-                cell.appendChild(makeRosterGrid(playerData.roster, Math.floor((cell.clientWidth - INDENT_W - POSITION_LABEL_W) / nRosterPositionTypes)))
-            }
-        } else if (playerData.roster) {
-            const INDENT_W         = 100
-            const POSITION_LABEL_W = 110
-            const nRosterPositionTypes = new Set(playerData.roster.slots.map(slot => slot.replace(/\d+$/, ''))).size
+        if (playerData.roster) {
             cell.appendChild(makePanelLabel('Roster assignments', '60px'))
-            cell.appendChild(makeRosterGrid(playerData.roster, Math.floor((cell.clientWidth - INDENT_W - POSITION_LABEL_W) / nRosterPositionTypes)))
+            cell.appendChild(makeRosterGrid(playerData.roster, nRosterPositionTypes))
         }
     }
 }
@@ -154,16 +135,17 @@ function makeGScoreTable(playerData: PlayerResult, categories: string[]): HTMLDi
     table.className = 'panel-table'
     table.style.tableLayout = 'fixed'
 
-    // Row 1: invisible spacers lock column widths.
-    const tableHead = table.createTHead()
-    const spacerRow = tableHead.insertRow(-1)
-    spacerRow.style.border = 'none'
-    spacerRow.appendChild(makeSpacerTh('panel-colspacer-name-sm'))
-    spacerRow.appendChild(makeSpacerTh('panel-colspacer-total'))
-    for (let index = 0; index < categories.length; index++) spacerRow.appendChild(makeSpacerTh())
+    // colgroup locks column widths without introducing a visual spacer row.
+    const colgroup = document.createElement('colgroup')
+    const nameCol  = document.createElement('col')
+    nameCol.style.width = '136px'   // matches .panel-colspacer-name-sm
+    const totalCol = document.createElement('col')
+    totalCol.style.width = '83px'   // matches .panel-colspacer-total
+    colgroup.append(nameCol, totalCol)
+    for (let index = 0; index < categories.length; index++) colgroup.appendChild(document.createElement('col'))
+    table.appendChild(colgroup)
 
-    // Row 2: visible column headers.
-    const headerRow = tableHead.insertRow(-1)
+    const headerRow = table.createTHead().insertRow(-1)
     headerRow.appendChild(makeSpacerTh('panel-colheader-blank'))
     const totalHeader = document.createElement('th')
     totalHeader.className = 'panel-colheader'
@@ -218,10 +200,13 @@ function makeWeightsTable(playerData: PlayerResult, categories: string[]): HTMLD
     table.className = 'panel-table'
     table.style.tableLayout = 'fixed'
 
-    const spacerRow = table.createTHead().insertRow(-1)
-    spacerRow.style.border = 'none'
-    spacerRow.appendChild(makeSpacerTh('panel-colspacer-weights'))
-    for (let index = 0; index < categories.length; index++) spacerRow.appendChild(makeSpacerTh())
+    // colgroup locks column widths without introducing a visual spacer row.
+    const colgroup = document.createElement('colgroup')
+    const labelCol = document.createElement('col')
+    labelCol.style.width = '219px'   // matches .panel-colspacer-weights
+    colgroup.appendChild(labelCol)
+    for (let index = 0; index < categories.length; index++) colgroup.appendChild(document.createElement('col'))
+    table.appendChild(colgroup)
 
     const row = table.createTBody().insertRow(-1)
     const labelCell = document.createElement('th')
@@ -256,26 +241,28 @@ function makeWeightsTable(playerData: PlayerResult, categories: string[]): HTMLD
  */
 function makeFlexAllocationsTable(
     flexData: FlexAllocations
-    , useMargin = true
-    , positionColumnWidth: number
+    , useMargin: boolean
+    , nTotalColumns: number
 ): HTMLDivElement {
     const positionNames = getPositionNames()
-
-    const POSITION_LABEL_W = 110  // matches .panel-colspacer-position-label
 
     const table = document.createElement('table')
     table.className = 'panel-table'
     table.style.tableLayout = 'fixed'
-    table.style.width = (POSITION_LABEL_W + flexData.base_positions.length * positionColumnWidth) + 'px'
+    table.style.width = '100%'
 
     const headerRow = table.createTHead().insertRow(-1)
     headerRow.appendChild(makeSpacerTh('panel-colheader-blank panel-colspacer-position-label'))
     for (const basePosition of flexData.base_positions) {
         const positionHeader = document.createElement('th')
         positionHeader.className = 'panel-colheader'
-        positionHeader.style.width = positionColumnWidth + 'px'
         positionHeader.textContent = positionNames[basePosition] ?? basePosition
         headerRow.appendChild(positionHeader)
+    }
+    // Invisible filler columns so this table's column count matches the roster's,
+    // giving each non-label column an identical width in both tables.
+    for (let i = flexData.base_positions.length; i < nTotalColumns; i++) {
+        headerRow.appendChild(makeSpacerTh('panel-colheader-blank'))
     }
 
     const tableBody = table.createTBody()
@@ -296,6 +283,13 @@ function makeFlexAllocationsTable(
                 cell.textContent = value.toFixed(2)
                 cell.style.cssText = stat_styler_tertiary(value, 50, 0)
             }
+        }
+        // Filler cells with border-style:hidden — in border-collapse mode, hidden
+        // borders override any neighbor's solid borders at the shared edge, so the
+        // row's bottom line does not extend into the filler region.
+        for (let i = rowData.values.length; i < nTotalColumns; i++) {
+            const filler = row.insertCell(-1)
+            filler.style.cssText = 'border-style: hidden; padding: 0;'
         }
     }
 
@@ -370,7 +364,7 @@ function makeAuctionValuesTable(playerData: PlayerResult): HTMLTableElement {
  * Builds the roster grid showing which players are assigned to each slot,
  * and highlights the candidate player being evaluated.
  */
-function makeRosterGrid(roster: Roster, positionColumnWidth: number): HTMLDivElement {
+function makeRosterGrid(roster: Roster, nTotalColumns: number): HTMLDivElement {
     const positionNames = getPositionNames()
 
     // Group slots by position type (e.g. "PG1", "PG2" → type "PG") preserving insertion order.
@@ -383,21 +377,23 @@ function makeRosterGrid(roster: Roster, positionColumnWidth: number): HTMLDivEle
     }
     const maxDepth = Math.max(...positionTypes.map(positionType => slotsByType[positionType].length))
 
-    const POSITION_LABEL_W = 110  // matches .panel-colspacer-position-label
-
     const table = document.createElement('table')
     table.className = 'panel-table'
     table.style.tableLayout = 'fixed'
-    table.style.width = (POSITION_LABEL_W + positionTypes.length * positionColumnWidth) + 'px'
+    table.style.width = '100%'
 
     const headerRow = table.createTHead().insertRow(-1)
     headerRow.appendChild(makeSpacerTh('panel-colheader-blank panel-colspacer-position-label'))
     for (const positionType of positionTypes) {
         const positionHeader = document.createElement('th')
         positionHeader.className = 'panel-colheader'
-        positionHeader.style.width = positionColumnWidth + 'px'
         positionHeader.textContent = positionNames[positionType] ?? positionType
         headerRow.appendChild(positionHeader)
+    }
+    // Invisible filler columns so this table's column count matches the flex
+    // allocations table's, giving each non-label column an identical width.
+    for (let i = positionTypes.length; i < nTotalColumns; i++) {
+        headerRow.appendChild(makeSpacerTh('panel-colheader-blank'))
     }
 
     const tableBody = table.createTBody()
@@ -428,6 +424,11 @@ function makeRosterGrid(roster: Roster, positionColumnWidth: number): HTMLDivEle
                     cell.textContent = assignment.name
                 }
             }
+        }
+        // See makeFlexAllocationsTable for the filler-cell rationale.
+        for (let i = positionTypes.length; i < nTotalColumns; i++) {
+            const filler = row.insertCell(-1)
+            filler.style.cssText = 'border-style: hidden; padding: 0;'
         }
     }
 

--- a/frontend/table/gscore_table.ts
+++ b/frontend/table/gscore_table.ts
@@ -37,16 +37,11 @@ export function renderTeamGScoreTable(
     tbl.style.tableLayout = 'fixed'
     tbl.style.width = '100%'
 
-    // Spacer row to lock column widths
-    const tHead = tbl.createTHead()
-    const spacerRow = tHead.insertRow(-1)
-    spacerRow.style.border = 'none'
-    spacerRow.appendChild(makeSpacerTh('panel-colspacer-name'))
-    spacerRow.appendChild(makeSpacerTh('panel-colspacer-total'))
-    for (let i = 0; i < categories.length; i++) spacerRow.appendChild(makeSpacerTh())
+    // colgroup locks column widths without introducing a visual spacer row.
+    tbl.appendChild(makeNameTotalCategoriesColgroup(categories.length))
 
     // Header row
-    const headerRow = tHead.insertRow(-1)
+    const headerRow = tbl.createTHead().insertRow(-1)
     headerRow.appendChild(makeSpacerTh())  // invisible label spacer
     const totalTh = document.createElement('th')
     totalTh.className = 'panel-colheader'
@@ -119,16 +114,7 @@ export function renderTeamGScoreTable(
     hScoreTbl.style.tableLayout = 'fixed'
     hScoreTbl.style.width = '100%'
 
-    // colgroup sets column widths to match the G-score table without a spacer row,
-    // so there is no gap between the outer border and the first data row.
-    const colgroup = document.createElement('colgroup')
-    const nameCol  = document.createElement('col')
-    nameCol.style.width = '200px'   // matches .panel-colspacer-name
-    const totalCol = document.createElement('col')
-    totalCol.style.width = '83px'   // matches .panel-colspacer-total
-    colgroup.append(nameCol, totalCol)
-    for (let i = 0; i < categories.length; i++) colgroup.appendChild(document.createElement('col'))
-    hScoreTbl.appendChild(colgroup)
+    hScoreTbl.appendChild(makeNameTotalCategoriesColgroup(categories.length))
 
     const hScoreTBody = hScoreTbl.createTBody()
     const hScoreRow = hScoreTBody.insertRow(-1)
@@ -164,4 +150,18 @@ function makeSpacerTh(extraClass?: string): HTMLTableCellElement {
     const th = document.createElement('th')
     th.className = extraClass ? `panel-colspacer ${extraClass}` : 'panel-colspacer'
     return th
+}
+
+/** Creates a `<colgroup>` with a 200px name column, an 83px total column, and
+ *  one auto-sized column per category. Used by both the G-score and H-score
+ *  tables so their column widths match. */
+function makeNameTotalCategoriesColgroup(nCategories: number): HTMLTableColElement {
+    const colgroup = document.createElement('colgroup')
+    const nameCol  = document.createElement('col')
+    nameCol.style.width = '200px'   // matches .panel-colspacer-name
+    const totalCol = document.createElement('col')
+    totalCol.style.width = '83px'   // matches .panel-colspacer-total
+    colgroup.append(nameCol, totalCol)
+    for (let i = 0; i < nCategories; i++) colgroup.appendChild(document.createElement('col'))
+    return colgroup
 }

--- a/frontend/table/player_table.ts
+++ b/frontend/table/player_table.ts
@@ -33,13 +33,12 @@ export function showTableMessage(message: string): void {
     cell.textContent = message
 }
 
-/** Rebuilds the H-score candidate table from scratch: clears old rows, creates headers, and populates player rows with styled cells.
- *  If players is null, only the headers are rendered (categories are known before evaluate runs). */
-export function buildTable(players: PlayerResult[] | null): void {
+/** Clears the candidate table and rebuilds its width container, column structure,
+ *  and header row. Categories, mode, and scoring format are read from the DOM. */
+export function buildTableHeader(): void {
 
     const categories = getSelectedCategories()
     const isAuction  = (document.getElementById('ls-mode') as HTMLInputElement).value === 'Auction Mode'
-    const isRoto     = getScoringFormat() === 'Rotisserie'
 
     const widthContainer = document.getElementById('panel-content-width-container')!
     widthContainer.style.minWidth = computeContentMinWidth()
@@ -47,7 +46,6 @@ export function buildTable(players: PlayerResult[] | null): void {
 
     table.innerHTML = ''
 
-    // ── Header ──────────────────────────────────────────────────────────────
     const thead = table.createTHead()
     const headerRow = thead.insertRow()
 
@@ -79,17 +77,25 @@ export function buildTable(players: PlayerResult[] | null): void {
         th.textContent = category
         headerRow.append(th)
     }
+}
 
-    if (players === null) return
+
+/** Rebuilds the H-score candidate table from scratch: clears old rows, creates headers, and populates player rows with styled cells. */
+export function buildTable(players: PlayerResult[]): void {
+
+    buildTableHeader()
+
+    const categories = getSelectedCategories()
+    const isAuction  = (document.getElementById('ls-mode') as HTMLInputElement).value === 'Auction Mode'
+    const isRoto     = getScoringFormat() === 'Rotisserie'
 
     // ── Player rows (built as HTML string for performance) ───────────────────
-    // Roto values hoisted outside the loop to avoid repeated lookups.
-    let nDrafters  = 0
-    let rotoMiddle = 0
-    if (isRoto) {
-        nDrafters  = getLeagueSettings().n_drafters
-        rotoMiddle = (nDrafters - 1) / 2 + 1
-    }
+    const rotoData = isRoto
+        ? (() => {
+              const nDrafters = getLeagueSettings().n_drafters
+              return { nDrafters, rotoMiddle: (nDrafters - 1) / 2 + 1 }
+          })()
+        : null
 
     let html = ''
     for (const [i, player] of players.entries()) {
@@ -116,9 +122,9 @@ export function buildTable(players: PlayerResult[] | null): void {
 
         // Category win rate cells
         for (const value of player.win_rates) {
-            if (isRoto) {
-                const rotoValue = 1 + (value / 100) * (nDrafters - 1)
-                html += `<td class='categoricalRotoHscore' style='${stat_styler_primary(rotoValue, 3 * (nDrafters - 1), rotoMiddle)}'>${rotoValue.toFixed(1)}</td>`
+            if (rotoData) {
+                const rotoValue = 1 + (value / 100) * (rotoData.nDrafters - 1)
+                html += `<td class='categoricalRotoHscore' style='${stat_styler_primary(rotoValue, 3 * (rotoData.nDrafters - 1), rotoData.rotoMiddle)}'>${rotoValue.toFixed(1)}</td>`
             } else {
                 html += `<td class='categoricalhscore' style='${stat_styler_primary(value, 3, 50)}'>${value.toFixed(1)}</td>`
             }


### PR DESCRIPTION
- table/: replace spacer-row pattern with <colgroup>; flatten the if/else tree in toggleExpandView so roster rendering happens once; drop placeholder zeros for roto values in favour of a rotoData object that's null when not roto; derive expand-panel position widths via 100%-width tables + invisible filler columns so the layout matches column-by-column without pixel math
- api/: add HTTPError class + jsonRequest helper to remove fetch/throw/json boilerplate from every endpoint; add withSessionRetry to collapse 4 duplicated 404-retry loops; tighten applyIndicatorState to take IndicatorState instead of string
- move makeDebouncer to api/session.ts and have fire() set the eval indicator immediately so the spinner appears on user action rather than after the debounce window