### PR TITLE
mobile responsive layout and sidebar overlay

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -197,6 +197,7 @@ def get_config_route(sport: str):
     return {
         'default_categories': p.get('default-categories', []),
         'all_categories': all_categories,
+        'short_category_names': p.get('short-category-names', {}),
         'options': options,
         'positions': raw_options.get('positions', {}),
         'position_structure': {

--- a/frontend/app.html
+++ b/frontend/app.html
@@ -14,6 +14,8 @@
 
     <div id="app-layout">
 
+        <button id="sidebar-toggle" type="button" aria-label="Toggle sidebar"></button>
+
         <aside id="sidebar" style="visibility: hidden">
             <div class="sidebar-title">Fantasy Sports Optimizer</div>
             <hr class="sidebar-divider">

--- a/frontend/app_state.ts
+++ b/frontend/app_state.ts
@@ -120,3 +120,7 @@ export function setSportConfig(c: SportConfig): void { sportConfig = c }
 
 /** Returns the position abbreviation → full name map (e.g. "PG" → "Point Guard"). */
 export function getPositionNames(): Record<string, string> { return sportConfig?.position_names ?? {} }
+
+/** Returns the full category name → short label map (e.g. "Points" → "pts").
+ *  Used by the candidate table on mobile to keep column headers compact. */
+export function getShortCategoryNames(): Record<string, string> { return sportConfig?.short_category_names ?? {} }

--- a/frontend/data_entry/auction_entry.ts
+++ b/frontend/data_entry/auction_entry.ts
@@ -17,8 +17,8 @@ import {
 
 const _auctionDebouncer = makeDebouncer(() => { runEvaluate().catch(err => console.error('Auction evaluate failed:', err)) })
 
-const ROUND_W = 46
-const TEAM_W  = 85
+const ROUND_W = 32
+const TEAM_W  = 60
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 

--- a/frontend/data_entry/draft_board.ts
+++ b/frontend/data_entry/draft_board.ts
@@ -22,8 +22,8 @@ const _draftDebouncer = makeDebouncer(() => { runEvaluate().catch(err => console
 
 let _autopilotRunning = false
 
-const ROUND_W = 46   // px — Round label column
-const TEAM_W  = 70   // px — per-drafter column (min-width floor only; table fills available width)
+const ROUND_W = 32   // px — Round label column
+const TEAM_W  = 50   // px — per-drafter column (min-width floor only; table fills available width)
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 

--- a/frontend/data_entry/season/season_rosters.ts
+++ b/frontend/data_entry/season/season_rosters.ts
@@ -3,7 +3,8 @@
 // inspector table (right).  Used by layout.ts for Season → Rosters tab.
 
 import { makeCustomSelect, CustomSelect } from '../../custom_select.js'
-import { getPlayerResults, getGScoreByName } from '../../app_state.js'
+import { getPlayerResults, getGScoreByName, getShortCategoryNames } from '../../app_state.js'
+import { isMobileViewport } from '../../helper_functions.js'
 import { DEFAULT_SEASON_ROSTERS } from './default_season_rosters.js'
 import { getSelectedCategories, getScoringFormat } from '../../parameter_collection/format_and_categories.js'
 import { getLeagueSettings } from '../../parameter_collection/league_settings.js'
@@ -294,7 +295,10 @@ async function buildTeamGScoreTable(
     spacerRow.appendChild(makeSpacerTh('panel-colspacer-total'))
     for (let i = 0; i < categories.length; i++) spacerRow.appendChild(makeSpacerTh())
 
-    // Header row
+    // Header row — on mobile, swap full category names for their short form
+    // (e.g. "Points" → "Pts") to keep columns narrow.
+    const isMobile   = isMobileViewport()
+    const shortNames = isMobile ? getShortCategoryNames() : {}
     const headerRow = tHead.insertRow(-1)
     headerRow.appendChild(makeSpacerTh())  // invisible label spacer
     const totalTh = document.createElement('th')
@@ -302,9 +306,10 @@ async function buildTeamGScoreTable(
     totalTh.textContent = 'Total'
     headerRow.appendChild(totalTh)
     for (const cat of categories) {
+        const label = shortNames[cat] ?? cat
         const th = document.createElement('th')
-        th.className = cat.length >= 10 ? 'panel-colheader colheader-long' : 'panel-colheader'
-        th.textContent = cat
+        th.className = label.length >= 10 ? 'panel-colheader colheader-long' : 'panel-colheader'
+        th.textContent = label
         headerRow.appendChild(th)
     }
 
@@ -383,11 +388,13 @@ async function buildTeamGScoreTable(
     hScoreTbl.className = 'panel-table panel-table--rounded panel-table--top-gap'
     hScoreTbl.style.tableLayout = 'fixed'
 
+    // Match the team-inspector's column widths above so the two tables line up.
+    // Mobile values mirror the #rosters-right .panel-colspacer-* overrides.
     const colgroup = document.createElement('colgroup')
     const nameCol  = document.createElement('col')
-    nameCol.style.width = '200px'
+    nameCol.style.width = isMobile ? '7rem' : '200px'
     const totalCol = document.createElement('col')
-    totalCol.style.width = '83px'
+    totalCol.style.width = isMobile ? '3rem' : '83px'
     colgroup.append(nameCol, totalCol)
     for (let i = 0; i < categories.length; i++) colgroup.appendChild(document.createElement('col'))
     hScoreTbl.appendChild(colgroup)

--- a/frontend/helper_functions.ts
+++ b/frontend/helper_functions.ts
@@ -2,6 +2,18 @@
 // Shared UI building blocks used across sidebar and parameter_collection modules.
 // Table-specific helpers (ExpandView and friends) live in table/expand_view.ts.
 
+// ─── Viewport breakpoint ──────────────────────────────────────────────────────
+// Mirrors the 768px breakpoint used by the @media (max-width: 768px) blocks in
+// styles.css. CSS handles layout-level switches; this is for the few cases
+// where rendering code (e.g. inline column widths, short vs full labels) has
+// to make the same mobile/desktop choice in JS.
+
+export const MOBILE_BREAKPOINT_PX = 768
+
+export function isMobileViewport(): boolean {
+    return window.innerWidth <= MOBILE_BREAKPOINT_PX
+}
+
 // ─── Global JS tooltip ────────────────────────────────────────────────────────
 // Uses position:fixed so it escapes the sidebar's overflow-y:auto clipping.
 // Any element with a `data-tooltip` attribute automatically gets a hover tooltip.

--- a/frontend/layout.ts
+++ b/frontend/layout.ts
@@ -42,10 +42,15 @@ export function getCurrentDraftTab():   string { return currentDraftTab   }
 /** Re-dispatches the layout with current DOM state. */
 export function applyLayout(): void {
     const { mode, platform } = getLeagueSettings()
+    const appLayout = document.getElementById('app-layout')!
 
     if (mode === 'Season Mode') {
+        // Mark season mode on the layout root so CSS can branch on it without
+        // having to inspect inline styles of #season-nav.
+        appLayout.classList.add('is-season')
         showSeasonLayout()
     } else {
+        appLayout.classList.remove('is-season')
         // Reset season tab tracking when leaving Season Mode so the next entry defaults to Waiver
         currentSeasonTab = null
         if (platform === 'Enter your own data') {

--- a/frontend/main.ts
+++ b/frontend/main.ts
@@ -246,6 +246,18 @@ themeInput.addEventListener('change', () => {
     setTheme(isLight ? 'light' : 'dark')
 })
 
+// ─── Sidebar toggle ───────────────────────────────────────────────────────────
+
+const SIDEBAR_COLLAPSE_BREAKPOINT = 768  // px; viewports narrower than this default to a collapsed sidebar
+const sidebarToggle = document.getElementById('sidebar-toggle') as HTMLButtonElement
+const appLayout     = document.getElementById('app-layout') as HTMLElement
+const defaultCollapsed = window.innerWidth < SIDEBAR_COLLAPSE_BREAKPOINT
+if (pref('sidebar_collapsed', defaultCollapsed)) appLayout.classList.add('sidebar-collapsed')
+sidebarToggle.addEventListener('click', () => {
+    const collapsed = appLayout.classList.toggle('sidebar-collapsed')
+    savePref('sidebar_collapsed', collapsed)
+})
+
 // ─── Bootstrap ────────────────────────────────────────────────────────────────
 
 // All sections are fully built; reveal the sidebar in one repaint

--- a/frontend/styles/styles.css
+++ b/frontend/styles/styles.css
@@ -5,6 +5,13 @@
 /* Scale all rem-based sizes with viewport width, min 16px (laptop), max 20px (wide desktop) */
 html { font-size: clamp(16px, 0.93vw, 20px); }
 
+/* On phones, shrink the root font so all rem-based widths (player col, score col,
+   categories, etc.) scale down proportionally — lets the candidate table fit in
+   viewport widths around 375-430px without horizontal scroll. */
+@media (max-width: 768px) {
+    html { font-size: 10px; }
+}
+
 /* ─── App layout ─────────────────────────────────────────────────────────── */
 
 #app-layout {
@@ -20,6 +27,107 @@ html { font-size: clamp(16px, 0.93vw, 20px); }
     overflow-y: auto;
     display: flex;
     flex-direction: column;
+}
+
+/* Hidden by default — only the mobile media block makes the toggle visible
+   and styles it. Desktop never shows it (the sidebar is always in flow). */
+#sidebar-toggle {
+    display: none;
+}
+
+/* Mobile: sidebar is a full-screen overlay. The closed state is a transform
+   off-screen, which is GPU-composited — so toggling the menu doesn't reflow
+   or repaint the candidate panel underneath. This is the entire point of this
+   architecture: the candidate panel never changes width, so the ~400ms paint
+   that previously occurred on every toggle is gone. */
+@media (max-width: 768px) {
+    #sidebar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100vw;
+        height: 100vh;
+        z-index: 50;
+        transition: transform 0.2s ease-out;
+        /* Pre-allocate a compositor layer so the slide is GPU-only — without
+           this hint, the browser may paint the sidebar contents on each
+           toggle. */
+        will-change: transform;
+    }
+    #app-layout.sidebar-collapsed #sidebar {
+        transform: translateX(-100%);
+    }
+    /* Hamburger / close toggle. Sits at top-right in BOTH open and closed
+       states — same fixed coordinates → no layout change on collapse, no
+       visual jump. Top: 22px vertically aligns the icon with the first row
+       of input boxes / dropdowns in both auction and draft modes (label is
+       at y≈8-20, input/dropdown follows at y≈22-50; toggle is 28px tall
+       and centers within that input). When the sidebar is open, the same
+       coordinates fall inside the .sidebar-title header strip. */
+    #sidebar-toggle {
+        display: flex;
+        position: fixed;
+        top: 22px;
+        right: 8px;
+        z-index: 100;
+        width: 32px;
+        height: 28px;
+        border: none;
+        background: transparent;
+        color: light-dark(#999999, #666688);
+        cursor: pointer;
+        font-family: "Source Sans 3";
+        font-size: 1.3rem;
+        line-height: 1;
+        align-items: center;
+        justify-content: center;
+    }
+    /* Hamburger when closed; X when open. Same font-size so the close
+       affordance doesn't look visually heavier than the open one. */
+    #sidebar-toggle::before {
+        content: '☰';
+    }
+    #app-layout:not(.sidebar-collapsed) #sidebar-toggle::before {
+        content: '✕';
+    }
+    /* Remove the browser's default focus ring on tap — otherwise it appears
+       as a boxy outline around the toggle after the first click. Keep focus
+       visible for keyboard navigation only. */
+    #sidebar-toggle:focus {
+        outline: none;
+    }
+    #sidebar-toggle:focus-visible {
+        outline: 2px solid light-dark(#999999, #666688);
+        outline-offset: 2px;
+    }
+    /* Right-side padding so the inputs / buttons row content doesn't slide
+       under the hamburger. */
+    #right-header:not(:empty) > :first-child,
+    #season-nav,
+    #live-bar {
+        padding-right: 40px;
+    }
+    /* Border-bottom on the sidebar title to demarcate it as a header bar in
+       the open-sidebar overlay. (The matching padding-bottom extension lives
+       in a separate mobile block after the base .sidebar-title rule — it
+       needs to come after the base `padding` shorthand to win the cascade.) */
+    .sidebar-title {
+        border-bottom: 1px solid light-dark(#e5e5e5, #3d3d55);
+    }
+    /* Push the season-mode tabs down to the bottom of the header so they
+       align with the border line — matching how they sit on desktop (where
+       the active tab's underline merges into season-nav's border-bottom).
+       The hamburger occupies the empty space ABOVE the tabs in the top-
+       right of this extended header area. */
+    #season-nav {
+        padding-top: 28px;
+    }
+    /* Season mode exception: #season-nav above gets the 40px right padding,
+       so #right-header sits below the toggle's vertical range and doesn't
+       need its own clearance. */
+    #app-layout.is-season #right-header:not(:empty) > :first-child {
+        padding-right: 0;
+    }
 }
 
 .section-apply-btn {
@@ -46,7 +154,18 @@ html { font-size: clamp(16px, 0.93vw, 20px); }
     font-family: "Source Sans 3";
     font-size: 1rem;
     font-weight: 700;
-    padding: 14px 16px 10px;
+    padding: 14px 48px 10px 16px;  /* extra right padding to clear #sidebar-toggle */
+}
+
+/* Mobile: extend the title bar's bottom padding so the bottom border sits
+   below the toggle (top: 22px + height 28px = 50px) instead of cutting
+   through it. Lives here, AFTER the base padding shorthand, to win the
+   same-specificity cascade — earlier mobile overrides of padding-bottom
+   alone are silently overridden by the base `padding` shorthand. */
+@media (max-width: 768px) {
+    .sidebar-title {
+        padding-bottom: 28px;
+    }
 }
 
 .sidebar-divider {
@@ -58,7 +177,14 @@ html { font-size: clamp(16px, 0.93vw, 20px); }
 #main-content {
     flex: 1;
     overflow-y: auto;
-    padding: 16px;
+    /* Single source of truth for the horizontal bounds of every main-column
+       element (pick-control row, entry table, candidate table). Children use
+       max-width: 100% and inherit this padding for their right/left edge —
+       no element computes its own calc(100vw - Npx). Mobile overrides these
+       variables to tighten the gutter; nothing else changes. */
+    --main-content-padding-left:  16px;
+    --main-content-padding-right: 16px;
+    padding: 8px var(--main-content-padding-right) 16px var(--main-content-padding-left);
 }
 
 /* ─── Sidebar sections (collapsible, mirroring Streamlit popovers) ───────── */
@@ -674,6 +800,7 @@ html { font-size: clamp(16px, 0.93vw, 20px); }
 }
 
 body {
+    margin: 0;
     background-color: light-dark(#ffffff, rgb(14, 17, 23));
     color: light-dark(#333333, lightgrey);
 }
@@ -750,7 +877,7 @@ tr {
     font-weight:400;
     font-size: 0.78rem;
     text-align: left;
-    width: 224px;
+    width: 6rem;
     border-top: 2px solid light-dark(#e5e5e5, #3d3d55);
     border-bottom: 2px solid light-dark(#e5e5e5, #3d3d55);
 }
@@ -945,6 +1072,8 @@ tr {
     text-align: left;
     border: 0.5px solid light-dark(#eeeeee, #555566);
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .panel-rowlabel-total {
@@ -1164,6 +1293,140 @@ tr {
     margin-left: auto;
 }
 
+/* Mobile pick-control-row layout. Mode-specific grid templates are defined
+   below via :has() — auction uses a 3-column grid with a fixed 5rem Cost
+   track, draft uses a single-column grid. Lives AFTER the base
+   `.pick-control-buttons` rule (immediately above) so the `margin-left: 0`
+   override inside the block wins the same-specificity cascade. */
+@media (max-width: 768px) {
+    .pick-control-row {
+        flex-wrap: wrap;
+        margin-top: 0;
+        margin-bottom: 8px;      /* matches #tab-row margin-top so spacing above and below the auction board is symmetric */
+    }
+    /* Auction mode (row contains the .auction-cost-input): use CSS Grid instead
+       of flex-wrap so the layout is explicit — Player/Drafter/Cost on row 1,
+       buttons span the whole of row 2. Flex-wrap was inconsistent about which
+       item wrapped first across browsers.
+       Tracks: minmax(0, 1fr) twice + a fixed 5rem for Cost. The 1fr tracks
+       have an explicit 0 lower bound so a grid item's min-content (long
+       player names, or the spanning buttons row) doesn't force the tracks
+       wider than the container. The Cost track is fixed-width instead of
+       `auto` because `auto` resolves to minmax(min-content, max-content),
+       which lets the column grow when a spanning item (the buttons row)
+       distributes its content size into it. */
+    .pick-control-row:has(.auction-cost-input) {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 5rem;
+        gap: 8px;
+        align-items: end;
+    }
+    .pick-control-row:has(.auction-cost-input) > .pick-control-buttons {
+        grid-column: 1 / -1;
+        /* Without this, the grid item's auto-min equals its content min-width
+           (the sum of three nowrap button labels, ~420px on mobile). That
+           min-width propagates into the tracks via the spanning-item rule and
+           pushes the grid wider than its 327px parent — the row visibly
+           overflows the right edge. min-width: 0 lets the buttons shrink. */
+        min-width: 0;
+    }
+    /* Draft mode (row contains .pick-control-label directly): single-column grid
+       so the "Select Pick X for Drafter Y" label sits above the dropdown,
+       mirroring the label-above-input layout used by auction mode's pick-cols.
+       Buttons take row 3. */
+    .pick-control-row:has(> .pick-control-label) {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 6px;
+    }
+    /* Spread the wrapped buttons row across the full viewport width: each button
+       gets an equal share, and the row's left edge anchors at x=0 (overrides
+       margin-left: auto). flex-basis: 100% forces the buttons onto their own
+       row inside the flex .pick-control-row (draft mode); auction mode uses
+       grid for the same row, where flex-basis is ignored — grid-column: 1 / -1
+       handles the wrap there. */
+    .pick-control-buttons {
+        margin-left: 0;
+        flex-grow: 1;
+        flex-basis: 100%;
+    }
+    .pick-control-buttons .pick-btn {
+        flex: 1;
+    }
+    /* Shrink the seat selector on mobile — at flex: 1 it grows to fill the tab
+       row, pushing the eval indicator and action buttons off-screen. */
+    #seat-selector-container {
+        flex: 0 1 auto;
+        max-width: 12rem;
+    }
+    /* Tighten the horizontal padding inside score / category cells — the 5px
+       default eats too much of the narrow column widths. */
+    .auction-dollar,
+    .overallhscore,
+    .categoricalhscore,
+    .categoricalRotoHscore {
+        padding: 5px 2px;
+    }
+    /* Tighten vertical spacing between the candidate-panel sections so there's
+       not a big empty band between the auction board and the candidate table. */
+    #right-header:not(:empty) {
+        margin-bottom: 0;
+    }
+    #tab-row {
+        margin-bottom: 8px;      /* matches margin-top so Select-team has equal space above and below */
+        margin-top: 8px;         /* small breath of space below the auction board */
+    }
+    /* Hide the vertical scrollbar gutter on the auction board — overflow: auto
+       reserves space for one even when not scrolling, eating ~15px of vertical
+       space below the board. */
+    .entry-table-scroll {
+        overflow-x: auto;
+        overflow-y: hidden;
+    }
+    /* Remove the seat-selector-wrap's bottom margin in tab-row context — it
+       was added for the season rosters layout but in #tab-row it pushes the
+       Select-team box's visual center upward relative to the eval indicator
+       and "Show candidates" buttons (flex align-items: center counts margins
+       in the item's outer box). */
+    #seat-selector-container .seat-selector-wrap {
+        margin-bottom: 0;
+    }
+    /* Single source of truth for the mobile main-column edges. Left padding
+       stays at 4px so content isn't flush against the viewport edge; right
+       padding is 0 so the auction board / candidate table extend all the way
+       to the viewport edge (combined with the ~15px overflow-y scrollbar
+       gutter, that already leaves enough space to read the rightmost data).
+       Every main-column element descends from #main-content and inherits
+       this right edge automatically. */
+    #main-content {
+        --main-content-padding-left:  4px;
+        --main-content-padding-right: 0;
+    }
+    #panel-content-width-container {
+        width: 100%;
+        /* Hard floor at 0 so no descendant's intrinsic min-content can stretch
+           the container past its `width: 100%`. Without this, a wide table
+           (e.g. the team-stats gscore view at desktop widths) inside the panel
+           could propagate its min-content up through the chain and visibly
+           stretch the page. With min-width: 0, content that doesn't fit gets
+           clipped or overflows inside the container instead. */
+        min-width: 0;
+    }
+    /* Season → Rosters tab: tighten the team-inspector's Player and Total
+       columns (200px/83px is fine on desktop but pushes per-category stats off
+       the right edge on mobile). Scoped to #rosters-right so other panel tables
+       elsewhere keep their desktop widths. */
+    #rosters-right .panel-colspacer-name  { width: 7rem; }
+    #rosters-right .panel-colspacer-total { width: 3rem; }
+    /* Season → Rosters tab: shrink the roster entry table's drafter columns —
+       at content-sized widths they fit only ~3 drafters before scrolling. The
+       cs-trigger inside each cell already has overflow: hidden so long player
+       names truncate cleanly. */
+    #rosters-left .entry-table th:not(:first-child) {
+        width: 4rem;
+    }
+}
+
 .pick-btn {
     padding: 5px 10px;
     white-space: nowrap;
@@ -1192,7 +1455,9 @@ tr {
 }
 
 .auction-cost-input {
-    width: 60px;
+    width: 5rem;
+    min-height: 28px;            /* match cs-trigger min-height so Cost matches dropdown row height */
+    box-sizing: border-box;
     padding: 4px 6px;
     font-size: 0.8rem;
     font-family: "Source Sans 3";
@@ -1276,6 +1541,7 @@ tr {
     justify-content: center;
     gap: 6px;
     font-size: 0.9rem;
+    box-sizing: border-box;
     color: light-dark(#aaaaaa, #666688);
     white-space: nowrap;
     flex-shrink: 0;
@@ -1316,6 +1582,29 @@ tr {
 
 .autopilot-running-indicator {
     width: auto;
+}
+
+/* Mobile: shrink both the width and the font so the indicator stays compact
+   AND the longer states ("Updating...", "Starting...") still fit inside the
+   box. Without the font shrink, the longer text overflows past the box edges
+   on both sides (justify-content: center) and visually overlaps the seat
+   selector to the left. */
+@media (max-width: 768px) {
+    .eval-indicator {
+        width: 7rem;
+        font-size: 0.85rem;
+        overflow: hidden;
+    }
+    /* Allow the "Show candidates" / "Show team statistics" tab-bar buttons to
+       wrap their text onto two lines on mobile so the right-sub-header takes
+       less horizontal space, leaving more room for the seat selector. Other
+       .pick-btn instances (Lock in / Undo / Clear) keep their default nowrap. */
+    .draft-tab-bar .pick-btn,
+    .auction-tab-bar .pick-btn {
+        white-space: normal;
+        line-height: 1.1;
+        text-align: center;
+    }
 }
 
 /* ─── Waiver controls bar ────────────────────────────────────────────────────── */

--- a/frontend/table/gscore_table.ts
+++ b/frontend/table/gscore_table.ts
@@ -2,10 +2,11 @@
 // Renders a G-score breakdown table for a list of players.
 // Used by Auction Mode's "My Team" tab and potentially by Season Mode roster inspection.
 
-import { getGScoreByName } from '../app_state.js'
+import { getGScoreByName, getShortCategoryNames } from '../app_state.js'
 import { getSelectedCategories, getScoringFormat } from '../parameter_collection/format_and_categories.js'
 import { getLeagueSettings } from '../parameter_collection/league_settings.js'
 import { stat_styler_primary } from '../styles/styler_functions.js'
+import { isMobileViewport } from '../helper_functions.js'
 
 /**
  * Builds a G-score table for the given players: one row per player plus a
@@ -37,8 +38,15 @@ export function renderTeamGScoreTable(
     tbl.style.tableLayout = 'fixed'
     tbl.style.width = '100%'
 
+    // On mobile, narrow the name/total columns and use short category labels
+    // (e.g. "Points" → "Pts") so the table's intrinsic min-content fits inside
+    // the candidate panel rather than stretching it. Matches the equivalent
+    // mobile treatment in season_rosters.ts's team inspector.
+    const isMobile   = isMobileViewport()
+    const shortNames = isMobile ? getShortCategoryNames() : {}
+
     // colgroup locks column widths without introducing a visual spacer row.
-    tbl.appendChild(makeNameTotalCategoriesColgroup(categories.length))
+    tbl.appendChild(makeNameTotalCategoriesColgroup(categories.length, isMobile))
 
     // Header row
     const headerRow = tbl.createTHead().insertRow(-1)
@@ -48,9 +56,10 @@ export function renderTeamGScoreTable(
     totalTh.textContent = 'Total'
     headerRow.appendChild(totalTh)
     for (const cat of categories) {
+        const label = shortNames[cat] ?? cat
         const th = document.createElement('th')
-        th.className = cat.length >= 10 ? 'panel-colheader colheader-long' : 'panel-colheader'
-        th.textContent = cat
+        th.className = label.length >= 10 ? 'panel-colheader colheader-long' : 'panel-colheader'
+        th.textContent = label
         headerRow.appendChild(th)
     }
 
@@ -114,7 +123,7 @@ export function renderTeamGScoreTable(
     hScoreTbl.style.tableLayout = 'fixed'
     hScoreTbl.style.width = '100%'
 
-    hScoreTbl.appendChild(makeNameTotalCategoriesColgroup(categories.length))
+    hScoreTbl.appendChild(makeNameTotalCategoriesColgroup(categories.length, isMobile))
 
     const hScoreTBody = hScoreTbl.createTBody()
     const hScoreRow = hScoreTBody.insertRow(-1)
@@ -152,15 +161,19 @@ function makeSpacerTh(extraClass?: string): HTMLTableCellElement {
     return th
 }
 
-/** Creates a `<colgroup>` with a 200px name column, an 83px total column, and
- *  one auto-sized column per category. Used by both the G-score and H-score
- *  tables so their column widths match. */
-function makeNameTotalCategoriesColgroup(nCategories: number): HTMLTableColElement {
+/** Creates a `<colgroup>` with name and total columns followed by one
+ *  auto-sized column per category. Desktop uses 200px/83px (matches
+ *  .panel-colspacer-name / .panel-colspacer-total); mobile uses 7rem/3rem so
+ *  the table fits inside the panel without forcing it wider. */
+function makeNameTotalCategoriesColgroup(
+    nCategories: number
+  , isMobile: boolean
+): HTMLTableColElement {
     const colgroup = document.createElement('colgroup')
     const nameCol  = document.createElement('col')
-    nameCol.style.width = '200px'   // matches .panel-colspacer-name
+    nameCol.style.width = isMobile ? '7rem' : '200px'
     const totalCol = document.createElement('col')
-    totalCol.style.width = '83px'   // matches .panel-colspacer-total
+    totalCol.style.width = isMobile ? '3rem' : '83px'
     colgroup.append(nameCol, totalCol)
     for (let i = 0; i < nCategories; i++) colgroup.appendChild(document.createElement('col'))
     return colgroup

--- a/frontend/table/player_table.ts
+++ b/frontend/table/player_table.ts
@@ -7,20 +7,26 @@ import { toggleExpandView } from './expand_view.js'
 import { PlayerResult } from '../types.js'
 import { getScoringFormat, getSelectedCategories } from '../parameter_collection/format_and_categories.js'
 import { getLeagueSettings } from '../parameter_collection/league_settings.js'
+import { getShortCategoryNames } from '../app_state.js'
+import { isMobileViewport } from '../helper_functions.js'
 
 const table = document.getElementById('hscoretable') as HTMLTableElement
 
 // ── Column widths ────────────────────────────────────────────────────────────
+// Floor values in rem (1rem = root font-size, see styles.css). Below these the
+// table is unreadable; above them the browser (table-layout: fixed) distributes
+// the extra width to category columns. Using rem so widths shrink alongside
+// the smaller mobile root font.
 
-const PLAYER_COL_W = 175
-const SCORE_COL_W  = 62
-const CAT_COL_W    = 74   // desired minimum width per category column
+const PLAYER_COL_W_REM = 5
+const SCORE_COL_W_REM  = 1.5
+const CAT_COL_W_REM    = 3      // desired minimum width per category column
 
 function computeContentMinWidth(): string {
     const isAuction  = (document.getElementById('ls-mode') as HTMLInputElement).value === 'Auction Mode'
     const nScoreCols = isAuction ? 4 : 1
     const categories = getSelectedCategories()
-    return (PLAYER_COL_W + nScoreCols * SCORE_COL_W + categories.length * CAT_COL_W) + 'px'
+    return (PLAYER_COL_W_REM + nScoreCols * SCORE_COL_W_REM + categories.length * CAT_COL_W_REM) + 'rem'
 }
 
 /** Clears the candidate table and shows a single centred message row. */
@@ -41,10 +47,22 @@ export function buildTableHeader(): void {
     const isAuction  = (document.getElementById('ls-mode') as HTMLInputElement).value === 'Auction Mode'
 
     const widthContainer = document.getElementById('panel-content-width-container')!
-    widthContainer.style.minWidth = computeContentMinWidth()
+    // The min-width acts as a desktop floor so the candidate table doesn't get
+    // unreadably narrow when the panel shrinks. On mobile the rem-scaled floor
+    // (e.g. 38rem in auction = 380px at the 10px root font) exceeds the viewport
+    // content width (~371px), and `min-width` beats `width: 100%`, so the
+    // container — and the whole chain inside it — gets pushed past the viewport
+    // right edge. Clear the floor on mobile and let `width: 100%` constrain.
+    widthContainer.style.minWidth = isMobileViewport() ? '' : computeContentMinWidth()
     table.style.minWidth = ''
 
     table.innerHTML = ''
+
+    const isMobile = isMobileViewport()
+    // Auction $ columns are quite narrow on mobile (since "Your $"/"Gnrc. $" headers
+    // truncate anyway), but on desktop they need room for the full headers.
+    const dollarColWidth = isMobile ? '1.5rem'  : '2.5rem'
+    const diffColWidth   = isMobile ? '1.25rem' : '2.5rem'
 
     const thead = table.createTHead()
     const headerRow = thead.insertRow()
@@ -52,7 +70,7 @@ export function buildTableHeader(): void {
     const playerTh = document.createElement('th')
     playerTh.className = 'tableheader'
     playerTh.textContent = 'Player'
-    playerTh.style.width = '224px'
+    playerTh.style.width = isMobile ? '6rem' : '14rem'
     headerRow.append(playerTh)
 
     if (isAuction) {
@@ -60,21 +78,25 @@ export function buildTableHeader(): void {
             const th = document.createElement('th')
             th.className = 'tableheader'
             th.textContent = label
-            th.style.width = '72px'
+            th.style.width = label === 'Diff.' ? diffColWidth : dollarColWidth
             headerRow.append(th)
         }
     } else {
         const th = document.createElement('th')
         th.className = 'tableheader'
         th.textContent = 'H-Score'
-        th.style.width = '72px'
+        th.style.width = '2.5rem'
         headerRow.append(th)
     }
 
+    // On mobile, swap each category's full name for its short form (e.g. "Points"
+    // → "pts") so the headers stay narrow.
+    const shortNames = isMobile ? getShortCategoryNames() : {}
     for (const category of categories) {
+        const label = shortNames[category] ?? category
         const th = document.createElement('th')
-        th.className = category.length >= 10 ? 'tableheader colheader-long' : 'tableheader'
-        th.textContent = category
+        th.className = label.length >= 10 ? 'tableheader colheader-long' : 'tableheader'
+        th.textContent = label
         headerRow.append(th)
     }
 }
@@ -88,6 +110,12 @@ export function buildTable(players: PlayerResult[]): void {
     const categories = getSelectedCategories()
     const isAuction  = (document.getElementById('ls-mode') as HTMLInputElement).value === 'Auction Mode'
     const isRoto     = getScoringFormat() === 'Rotisserie'
+
+    // Mobile shows integer-rounded values so columns can stay narrow ("47" vs "47.5").
+    // Desktop keeps 1-decimal precision since there's room. H-Score keeps 1-decimal
+    // on both viewports (see below) — it differentiates closely-ranked players.
+    // Uses the same 768px breakpoint as the smaller root font in styles.css.
+    const decimals = isMobileViewport() ? 0 : 1
 
     // ── Player rows (built as HTML string for performance) ───────────────────
     const rotoData = isRoto
@@ -109,14 +137,16 @@ export function buildTable(players: PlayerResult[]): void {
             const av = player.auction_values
             if (av) {
                 const diff = av.your_dollar - av.gnrc_dollar
-                html += `<td class='auction-dollar' style='${stat_styler_secondary(diff, 10, 0)}'>${diff.toFixed(1)}</td>`
+                html += `<td class='auction-dollar' style='${stat_styler_secondary(diff, 10, 0)}'>${diff.toFixed(decimals)}</td>`
                 for (const val of [av.your_dollar, av.gnrc_dollar, av.orig_dollar]) {
-                    html += `<td class='auction-dollar celltypeb'>${val.toFixed(1)}</td>`
+                    html += `<td class='auction-dollar celltypeb'>${val.toFixed(decimals)}</td>`
                 }
             } else {
                 for (let j = 0; j < 4; j++) html += `<td class='auction-dollar'>—</td>`
             }
         } else {
+            // H-Score keeps 1-decimal precision even on mobile — it differentiates
+            // closely-ranked players (e.g. 52.5% vs 52.3%) which integer rounding flattens.
             html += `<td class='overallhscore'>${player.h_score.toFixed(1)}</td>`
         }
 
@@ -124,9 +154,9 @@ export function buildTable(players: PlayerResult[]): void {
         for (const value of player.win_rates) {
             if (rotoData) {
                 const rotoValue = 1 + (value / 100) * (rotoData.nDrafters - 1)
-                html += `<td class='categoricalRotoHscore' style='${stat_styler_primary(rotoValue, 3 * (rotoData.nDrafters - 1), rotoData.rotoMiddle)}'>${rotoValue.toFixed(1)}</td>`
+                html += `<td class='categoricalRotoHscore' style='${stat_styler_primary(rotoValue, 3 * (rotoData.nDrafters - 1), rotoData.rotoMiddle)}'>${rotoValue.toFixed(decimals)}</td>`
             } else {
-                html += `<td class='categoricalhscore' style='${stat_styler_primary(value, 3, 50)}'>${value.toFixed(1)}</td>`
+                html += `<td class='categoricalhscore' style='${stat_styler_primary(value, 3, 50)}'>${value.toFixed(decimals)}</td>`
             }
         }
 

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -9,6 +9,7 @@ export interface ParamOption {
 export interface SportConfig {
     default_categories: string[]
     all_categories: string[]
+    short_category_names: Record<string, string>
     options: Record<string, ParamOption>
     positions: Record<string, { base: Record<string, number>; flex: Record<string, number> }>
     position_structure: {

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -1,4 +1,21 @@
 NBA:
+  short-category-names:
+    Field Goal %: FG%
+    Free Throw %: FT%
+    Three %: 3%
+    Threes: 3s
+    Points: Pts
+    Rebounds: Rbds
+    Assists: Asts
+    Steals: Stls
+    Blocks: Blks
+    Turnovers: Tos
+    Def Rebounds: dRbds
+    Off Rebounds: oRbds
+    Assist to TO: A/To
+    Double Doubles: DDs
+    Field Goals Made: FGM
+    Free Throws Made: FTM
   default-categories:
     - Field Goal %
     - Free Throw %
@@ -6,7 +23,7 @@ NBA:
     - Points
     - Rebounds
     - Assists
-    - Steals 
+    - Steals
     - Blocks
     - Turnovers
   counting-statistics:
@@ -14,12 +31,12 @@ NBA:
     - Points
     - Rebounds
     - Assists
-    - Steals 
+    - Steals
     - Blocks
     - Turnovers
     - Def Rebounds
     - Off Rebounds
-    - Double Doubles 
+    - Double Doubles
     - Field Goals Made
     - Free Throws Made
   ratio-statistics: 
@@ -342,6 +359,23 @@ NBA:
   n_games : 82
   n_games_per_week : 3
 WNBA:
+  short-category-names:
+    Field Goal %: FG%
+    Free Throw %: FT%
+    Three %: 3%
+    Threes: 3s
+    Points: Pts
+    Rebounds: Rbds
+    Assists: Asts
+    Steals: Stls
+    Blocks: Blks
+    Turnovers: Tos
+    Def Rebounds: dRbds
+    Off Rebounds: oRbds
+    Assist to TO: A/To
+    Double Doubles: DDs
+    Field Goals Made: FGM
+    Free Throws Made: FTM
   default-categories:
     - Field Goal %
     - Free Throw %
@@ -349,7 +383,7 @@ WNBA:
     - Points
     - Rebounds
     - Assists
-    - Steals 
+    - Steals
     - Blocks
     - Turnovers
   counting-statistics:
@@ -569,15 +603,38 @@ WNBA:
   n_games : 40
   n_games_per_week : 3
 MLB:
+  short-category-names:
+    Runs: R
+    Home Runs: HR
+    RBI: RBI
+    Stolen Bases: SBs
+    Batting Average: AVG
+    Slugging %: SLG
+    On Base %: OBP
+    Wins: W
+    Saves: SV
+    Strikeouts: Ks
+    ERA: ERA
+    WHIP: WHIP
+    K/9: K/9
+    K/BB: K/BB
+    Hits: H
+    Doubles: 2B
+    Triples: 3B
+    Total Bases: TB
+    Losses: L
+    Quality Starts: QS
+    Holds: HLD
+    Saves and Holds: SVH
   default-categories:
     - Runs
-    - Home Runs 
-    - RBI 
-    - Stolen Bases 
+    - Home Runs
+    - RBI
+    - Stolen Bases
     - Batting Average
-    - Wins 
+    - Wins
     - Saves
-    - Strikeouts 
+    - Strikeouts
     - ERA
     - WHIP
   counting-statistics:


### PR DESCRIPTION
- Mobile sidebar becomes a full-screen overlay that slides in via GPU-composited transform; eliminates the ~400ms paint that previously occurred when the candidate panel resized on every toggle.
- Hamburger toggle replaces the sidebar arrow on mobile; sits at a fixed top-right position so it stays put when the menu opens/closes.
- Extended sidebar title + season-nav padding on mobile so the header strip visually contains the toggle in both open and closed states.
- Short category names (Pts, Rbds, Asts, ...) wired through backend config to candidate / gscore / rosters tables on mobile, keeping columns narrow.
- Auction grid template switches Cost to a fixed 5rem track with minmax(0, 1fr) on Player/Drafter to prevent min-content from inflating the row past its parent.
- panel-content-width-container gets explicit min-width: 0 on mobile as a structural guarantee against descendant content stretching the chain.
- player_table skips its desktop-floor min-width on mobile so the chain stays clamped to viewport.
- Removed stale arrow/rotation toggle rules, dead .pick-control-buttons margin-left override, and other accumulated cruft.