### PR TITLE
fix dom memory leaks and widen mobile player column

### DIFF
--- a/frontend/custom_select.ts
+++ b/frontend/custom_select.ts
@@ -9,15 +9,24 @@
 //   container.append(sel.element)
 //   sel.element.addEventListener('change', () => console.log(sel.getValue()))
 //
-// Getter compatibility: a hidden <select id={id}> is kept in sync so that
+// Getter compatibility: a hidden <input id={id}> is kept in sync so that
 // existing getter code like:
-//   (document.getElementById('my-id') as HTMLSelectElement).value
+//   (document.getElementById('my-id') as HTMLInputElement).value
 // continues to work without modification.
 //
-// <select> is used (rather than <input type="hidden">) because a sibling
-// <label for={id}> requires a labelable element per the HTML spec, and
-// <input type="hidden"> is explicitly excluded from that list. Using <select>
-// silences Chrome's "label's for attribute doesn't match any element id" warning.
+// The hidden value carrier is <input type="text" hidden>, not <select>.
+// Two constraints had to be satisfied at once:
+//   (1) it must be a labelable element so <label for={id}> resolves cleanly
+//       and Chrome doesn't warn — that rules out <input type="hidden">, which
+//       is explicitly excluded from the labelable list.
+//   (2) it must not be a heavy native form element with many children. A
+//       <select> populated with hundreds of <option>s creates internal
+//       shadow DOM (slot + label container + ShadowRoot per option) that
+//       browsers don't release cleanly on detach, producing massive detached-
+//       DOM leaks when the widget is recreated repeatedly (~half a gigabyte
+//       observed with 156 selects × 300 options × N renders).
+// <input type="text" hidden> satisfies both: it's labelable per the spec, and
+// it has no internal rendering or option children.
 
 export interface CustomSelectOption {
     value: string
@@ -34,15 +43,16 @@ export interface CustomSelect {
 /**
  * Creates a fully browser-rendered custom select widget.
  *
- * A `<select id={id} hidden>` is kept in sync inside the wrapper so that
- * existing getter code like `(document.getElementById(id) as HTMLSelectElement).value`
+ * An `<input type="text" id={id} hidden>` is kept in sync inside the wrapper
+ * so that existing getter code like `(document.getElementById(id) as HTMLInputElement).value`
  * continues to work without modification, and so that a sibling `<label for={id}>`
- * references a labelable element (which <input type="hidden"> is not).
+ * references a labelable element. See the file header for why this is a hidden
+ * text input rather than <select> or <input type="hidden">.
  *
  * The wrapper element dispatches a native `'change'` event (bubbling) whenever the
  * selected value changes, so `element.addEventListener('change', cb)` works as expected.
  *
- * @param id           - DOM id; also used for the hidden <select> that exposes `.value`
+ * @param id           - DOM id; also used for the hidden <input> that exposes `.value`
  * @param options      - Initial option list
  * @param defaultValue - Initially selected value; falls back to `options[0]` if omitted
  */
@@ -62,22 +72,29 @@ export function makeCustomSelect(
     const wrapper = document.createElement('div')
     wrapper.className = 'cs-wrapper'
 
-    // Hidden <select> — exposes the current value via (document.getElementById(id) as HTMLSelectElement).value,
-    // and gives a sibling <label for={id}> a labelable target so Chrome doesn't warn.
-    const hiddenSelect = document.createElement('select')
-    hiddenSelect.id = id
-    hiddenSelect.hidden = true
-    hiddenSelect.tabIndex = -1
-
-    function syncHiddenSelectOptions(opts: CustomSelectOption[]): void {
-        hiddenSelect.replaceChildren(...opts.map(o => {
-            const optionEl = document.createElement('option')
-            optionEl.value = o.value
-            optionEl.textContent = o.label
-            return optionEl
-        }))
-    }
-    syncHiddenSelectOptions(currentOptions)
+    // Hidden value carrier — exposes the current value via
+    // (document.getElementById(id) as HTMLInputElement).value, and gives a
+    // sibling <label for={id}> a labelable target.
+    //
+    // Uses <input type="text" hidden> rather than <select>: a native <select>
+    // populated with N options creates N pieces of internal shadow DOM (slot +
+    // label container + ShadowRoot per option) that the browser keeps alive
+    // even after the element is detached. With ~300 options × 156 selects per
+    // renderSeasonRosters call, that produced ~half a gigabyte of detached DOM
+    // that GC could not reclaim.
+    //
+    // <input type="hidden"> would be even simpler but is explicitly excluded
+    // from the HTML spec's labelable-element list — <label for={id}> against
+    // it triggers Chrome's "label's for attribute doesn't match any element"
+    // warning. <input type="text"> IS labelable; combined with the `hidden`
+    // attribute it's invisible and non-interactive, and it has no internal
+    // children to leak.
+    const hiddenValueInput = document.createElement('input')
+    hiddenValueInput.type = 'text'
+    hiddenValueInput.id = id
+    hiddenValueInput.hidden = true
+    hiddenValueInput.tabIndex = -1
+    hiddenValueInput.autocomplete = 'off'
 
     // Visible trigger
     const trigger = document.createElement('div')
@@ -101,7 +118,7 @@ export function makeCustomSelect(
     dropdown.className = 'cs-dropdown'
     dropdown.hidden = true
 
-    wrapper.append(hiddenSelect, trigger, dropdown)
+    wrapper.append(hiddenValueInput, trigger, dropdown)
 
     // ── Internal helpers ───────────────────────────────────────────────────
 
@@ -111,7 +128,7 @@ export function makeCustomSelect(
 
     function commit(value: string, silent = false): void {
         currentValue       = value
-        hiddenSelect.value = value
+        hiddenValueInput.value = value
         searchInput.value  = getLabelFor(value)
         if (!silent) wrapper.dispatchEvent(new Event('change', { bubbles: true }))
     }
@@ -226,7 +243,6 @@ export function makeCustomSelect(
 
     function setOptions(opts: CustomSelectOption[], preferredValue?: string): void {
         currentOptions = [...opts]
-        syncHiddenSelectOptions(currentOptions)
         const keep = preferredValue ?? currentValue
         const resolved = currentOptions.find(o => o.value === keep)?.value
                       ?? currentOptions[0]?.value ?? ''

--- a/frontend/data_entry/season/season_rosters.ts
+++ b/frontend/data_entry/season/season_rosters.ts
@@ -11,8 +11,23 @@ import { getLeagueSettings } from '../../parameter_collection/league_settings.js
 import { stat_styler_primary } from '../../styles/styler_functions.js'
 import { evaluateTeamHScore } from '../../api/season_session.js'
 
+// Tracks the change-event listeners attached by the most recent render so they
+// can be removed before the next one. Without this, calling renderSeasonRosters
+// a second time (e.g. revisiting Season Mode) leaves listener closures bound to
+// the now-detached previous selects. Each closure captures `selects` (156 custom
+// selects × ~300 options) and `rebuildInspector`, so the entire previous render
+// tree stays alive in memory. Aborting this controller before the new render
+// detaches all listeners at once — no manual iteration, no missed cleanup.
+let rosterListenerController: AbortController | null = null
+
 /** Renders the season roster entry grid (left) and team inspector with G-score table (right). */
 export function renderSeasonRosters(leftEl: HTMLElement, rightEl: HTMLElement): void {
+
+    // Remove change listeners from any previously-rendered selects so their
+    // closures can be garbage-collected. See comment on rosterListenerController.
+    rosterListenerController?.abort()
+    rosterListenerController = new AbortController()
+    const listenerOpts = { signal: rosterListenerController.signal }
     const playerResults = getPlayerResults()
     if (playerResults === null) return
 
@@ -136,7 +151,7 @@ export function renderSeasonRosters(leftEl: HTMLElement, rightEl: HTMLElement): 
             dragging  = true
         }
         applySelectionHighlight()
-    })
+    }, listenerOpts)
 
     table.addEventListener('mousemove', (e: MouseEvent) => {
         if (!dragging) return
@@ -147,9 +162,9 @@ export function renderSeasonRosters(leftEl: HTMLElement, rightEl: HTMLElement): 
             focusCol = coords.col
             applySelectionHighlight()
         }
-    })
+    }, listenerOpts)
 
-    document.addEventListener('mouseup', () => { dragging = false })
+    document.addEventListener('mouseup', () => { dragging = false }, listenerOpts)
 
     table.addEventListener('keydown', (e: KeyboardEvent) => {
         const ctrl = e.ctrlKey || e.metaKey
@@ -204,7 +219,7 @@ export function renderSeasonRosters(leftEl: HTMLElement, rightEl: HTMLElement): 
                 if (changed) rebuildInspector()
             })
         }
-    })
+    }, listenerOpts)
 
     scroll.append(table)
     leftEl.append(scroll)
@@ -238,12 +253,12 @@ export function renderSeasonRosters(leftEl: HTMLElement, rightEl: HTMLElement): 
     }
 
     // Rebuild when the team selector changes
-    teamSel.element.addEventListener('change', rebuildInspector)
+    teamSel.element.addEventListener('change', rebuildInspector, listenerOpts)
 
     // Rebuild when any roster select changes
     for (const rowSelects of selects) {
         for (const sel of rowSelects) {
-            sel.element.addEventListener('change', rebuildInspector)
+            sel.element.addEventListener('change', rebuildInspector, listenerOpts)
         }
     }
 

--- a/frontend/helper_functions.ts
+++ b/frontend/helper_functions.ts
@@ -239,11 +239,20 @@ export function makeMultiSelectWidget(
 
     const callbacks: (() => void)[] = []
 
+    // Reuses a single MutationObserver across re-renders. Without this, every
+    // call to observeInputArea (initial + each replaceSelection) created a new
+    // observer without disconnecting the previous one — the old observer kept
+    // watching its (now-detached) input area, with its callback closure rooted
+    // by V8's observer registry. Same re-render-leak pattern as the prior
+    // <select> bug.
+    let inputAreaObserver: MutationObserver | null = null
+
     function observeInputArea(): void {
+        inputAreaObserver?.disconnect()
         const inputArea = wrap.querySelector('.ms-input-area')
         if (inputArea) {
-            new MutationObserver(() => callbacks.forEach(cb => cb()))
-                .observe(inputArea, { childList: true })
+            inputAreaObserver = new MutationObserver(() => callbacks.forEach(cb => cb()))
+            inputAreaObserver.observe(inputArea, { childList: true })
         }
     }
     observeInputArea()

--- a/frontend/table/player_table.ts
+++ b/frontend/table/player_table.ts
@@ -70,7 +70,7 @@ export function buildTableHeader(): void {
     const playerTh = document.createElement('th')
     playerTh.className = 'tableheader'
     playerTh.textContent = 'Player'
-    playerTh.style.width = isMobile ? '6rem' : '14rem'
+    playerTh.style.width = isMobile ? '11rem' : '14rem'
     headerRow.append(playerTh)
 
     if (isAuction) {


### PR DESCRIPTION
- custom_select.ts: swap the per-widget hidden <select> for <input type="text" hidden>. The <select> populated with 300 player <option> children was creating internal shadow DOM (slot + label container + ShadowRoot per option) that browsers retained even after detach — ~half a gigabyte of detached DOM accumulated across season rosters re-renders. <input type="text"> is labelable per the HTML spec (only type="hidden" is excluded), keeps the .value API external code reads, and has no shadow DOM to leak.
- season_rosters.ts: route all 6 listener registrations through an AbortController so they get torn down before the next render, instead of leaving closures bound to detached selects (and a document mouseup listener that previously accumulated permanently).
- helper_functions.ts: reuse a single MutationObserver across the multiselect widget's re-renders instead of creating a new one in observeInputArea every call — same re-render-leak shape as the rest.
- player_table.ts: bump the mobile Player column from 6rem to 11rem so most player names fit without truncation; the candidate table's fixed layout reclaims the space from the auto-sized category columns.