### PR TITLE
Drop cryptography version cap that broke the cloud build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ uvicorn[standard]>=0.29.0
 python-multipart>=0.0.9
 authlib>=1.3.0          # Google OAuth / OIDC login
 itsdangerous>=2.1.0     # signs the session cookie (Starlette SessionMiddleware)
-cryptography>=41.0.5,<45  # pin: authlib pulls latest, but pyOpenSSL 24.x (snowflake) needs <45
 lxml
 streamlit==1.48.1
 streamlit-extras


### PR DESCRIPTION
The <45 cap was a local-only band-aid; in a fresh resolve it forced pip to backtrack snowflake-connector-python to an ancient source release (2.9.0 -> pyarrow 8.0.0 source build -> pkg_resources error). Let cryptography resolve transitively via snowflake + authlib instead.