### PR TITLE
Add httpx (required by authlib's Starlette OAuth integration)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastapi>=0.111.0
 uvicorn[standard]>=0.29.0
 python-multipart>=0.0.9
 authlib>=1.3.0          # Google OAuth / OIDC login
+httpx                   # async HTTP client used by authlib's Starlette OAuth integration
 itsdangerous>=2.1.0     # signs the session cookie (Starlette SessionMiddleware)
 lxml
 streamlit==1.48.1


### PR DESCRIPTION
authlib.integrations.starlette_client imports httpx for its async OAuth HTTP calls; it's an optional authlib dep, so the slim Cloud image didn't have it, crashing at startup with ModuleNotFoundError: No module named 'httpx'.