### PR TITLE
Require SESSION_SECRET_KEY (no silent fallback); split secrets vs config

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -19,16 +19,13 @@ Optional:
 from __future__ import annotations
 
 import hashlib
-import logging
-import secrets
+import os
 from typing import Optional
 
 from authlib.integrations.starlette_client import OAuth
 from fastapi import HTTPException, Request
 
 from backend.secret_config import get_secret
-
-logger = logging.getLogger('fbbo.auth')
 
 _GOOGLE_METADATA_URL = 'https://accounts.google.com/.well-known/openid-configuration'
 
@@ -43,25 +40,28 @@ oauth.register(
     client_kwargs={'scope': 'openid email profile'},
 )
 
-# Used only when SESSION_SECRET_KEY is unset (local dev) — logins reset when the process
-# restarts. Production must set SESSION_SECRET_KEY.
-_DEV_FALLBACK_SECRET = secrets.token_hex(32)
-
-
 def session_secret_key() -> str:
+    """The key that signs the login session cookie. Required, with no fallback: a per-process
+    random key would silently break logins across restarts / multiple instances (a process
+    that didn't sign the OAuth-state cookie can't verify it). Fail loudly if it's missing."""
     secret = get_secret('SESSION_SECRET_KEY')
-    if secret:
-        return secret
-    logger.warning('SESSION_SECRET_KEY not set; using an ephemeral key (logins reset on restart).')
-    return _DEV_FALLBACK_SECRET
+    if not secret:
+        raise RuntimeError(
+            'SESSION_SECRET_KEY is not set (environment or .streamlit/secrets.toml). It signs '
+            'the login session cookie and must be a stable secret value. Generate one with: '
+            'python -c "import secrets; print(secrets.token_hex(32))"'
+        )
+    return secret
 
 
 def session_https_only() -> bool:
-    return (get_secret('SESSION_HTTPS_ONLY') or '').lower() in ('1', 'true', 'yes')
+    # Plain deployment flag, not a secret — read straight from the environment.
+    return os.environ.get('SESSION_HTTPS_ONLY', '').lower() in ('1', 'true', 'yes')
 
 
 def _allowed_emails() -> Optional[set[str]]:
-    raw = (get_secret('AUTH_ALLOWED_EMAILS') or '').strip()
+    # A (non-secret) allowlist of emails; environment config, not a secret.
+    raw = os.environ.get('AUTH_ALLOWED_EMAILS', '').strip()
     if not raw:
         return None   # no allowlist -> any verified Google account may sign in
     return {email.strip().lower() for email in raw.split(',') if email.strip()}

--- a/backend/main.py
+++ b/backend/main.py
@@ -289,7 +289,7 @@ async def _revalidate_app_assets(request: Request, call_next):
 @app.get('/auth/login')
 async def auth_login_route(request: Request):
     """Kick off the Google sign-in redirect."""
-    redirect_uri = get_secret('OAUTH_REDIRECT_URI') or str(request.url_for('auth_callback_route'))
+    redirect_uri = os.environ.get('OAUTH_REDIRECT_URI') or str(request.url_for('auth_callback_route'))
     return await oauth.google.authorize_redirect(request, redirect_uri)
 
 

--- a/testing_files/conftest.py
+++ b/testing_files/conftest.py
@@ -1,6 +1,10 @@
 import sys
 import os
 
+# The app requires SESSION_SECRET_KEY (it signs the login cookie; no fallback). Tests do no
+# real OAuth, so a dummy value is fine — set it before any test imports backend.main.
+os.environ.setdefault('SESSION_SECRET_KEY', 'test-only-session-secret')
+
 # Add the testing_files/ directory to sys.path so that benchmark_helpers
 # can be imported by the benchmark_* test modules without a package prefix.
 # Pytest's working directory is the project root, so this directory would


### PR DESCRIPTION
- session_secret_key() now raises if unset instead of fabricating a per-process ephemeral key, which silently broke logins across restarts / Cloud Run instances (the OAuth-state cookie couldn't be verified by another process). Fail loudly per CLAUDE.md rather than mask a missing required value.
- Non-secret config (SESSION_HTTPS_ONLY, OAUTH_REDIRECT_URI, AUTH_ALLOWED_EMAILS) now reads from os.environ, not the get_secret() secrets resolver.
- conftest sets a dummy SESSION_SECRET_KEY so the suite still imports the app.