### PR TITLE
feat: transpose the draft board on mobile + mobile stat-text fixes

### DIFF
--- a/draft_board_mobile_transpose_spec.md
+++ b/draft_board_mobile_transpose_spec.md
@@ -1,0 +1,140 @@
+# Spec: transpose the draft board on mobile (teams as rows, rounds as columns)
+
+## Goal
+On mobile, render the own-data Draft board **transposed** so team names live in a **frozen first
+column** (always visible) and rounds run left-to-right as columns — so the user scrolls right as the
+draft progresses and never loses track of whose row they're on. Desktop keeps the current
+orientation (rounds as rows, teams as columns), which suits wide screens.
+
+## Current behavior (as-is)
+- `draft_board.ts` renders rounds-as-rows: `<thead>` = `Round | Team 1 | Team 2 | … | Team N` (each
+  team `th` holds the `.team-header` widget = editable label input + compact method dropdown);
+  `<tbody>` = one row per round (`round# | pick | pick | …`).
+- Render split (built earlier): the scaffold (pick-control slot + table **header**) is built once per
+  config via `buildScaffold`; the team-header widgets persist (so editing a label keeps focus and the
+  method-dropdown listeners don't churn). Only the pick control and `rebuildBoardBody` (which replaces
+  the whole `<tbody>`) rebuild per pick. Two controllers: `pickListenerController` (per render),
+  `headerListenerController` (per scaffold). Module state: `boardTable`, `pickControlSlot`.
+- Mobile shows the same orientation → many team columns overflow horizontally, and the team names
+  (column headers) scroll off the top when you scroll right, so you can't tell which column is whom.
+- `isMobileViewport()` = `window.innerWidth <= 768`. There are **no resize listeners** in the app —
+  no component reflows on raw resize today; orientation is effectively chosen at render time.
+
+## Target behavior (to-be)
+- **Desktop (> 768px):** unchanged — rounds as rows, teams as columns.
+- **Mobile (≤ 768px):** transposed —
+  - `<thead>` = `[corner] | 1 | 2 | … | nPicks` (round numbers as columns).
+  - one `<tbody>` row per team: `[sticky team header] | pick | pick | …` across rounds.
+  - the team-header column is **`position: sticky; left: 0`** so names stay visible while scrolling
+    right through rounds.
+  - the current pick is highlighted at its `(team row, round column)` cell, and the board
+    **auto-scrolls** that round column into view as picks advance.
+
+## Design decisions
+- **Mobile-only alternate layout**, chosen at render time via `isMobileViewport()`. Desktop is
+  untouched in appearance/behavior.
+- **Keep the existing build-once-header + rebuild-data model; desktop is untouched.** The one wrinkle
+  is that HTML tables are row-major: `<thead>`/`<tbody>`/`<tr>` are structural units but a *column* is
+  not — a column's cells are scattered one-per-row. So the desktop trick (team headers in a separate
+  `<thead>`, replace the whole `<tbody>`) has no exact column equivalent. The symmetric move in the
+  transposed layout is simply **per-row**: each team row's *first cell* is the persistent team header
+  (built once, sticky), and per pick we rebuild only that row's *trailing* (pick) cells. Same idea —
+  header persists, data rebuilt — applied to each row's tail instead of the whole body. No desktop
+  changes, no cell-patching.
+- **No raw-resize reflow required for v1.** Consistent with the rest of the app (which doesn't reflow
+  on resize), orientation is picked on the next natural render. A debounced resize re-render that
+  flips orientation live is an **optional** add-on (§7).
+
+## Architecture / changes (`frontend/data_entry/draft_board.ts`)
+
+### 1. Orientation state + scaffold trigger
+- Module state: `let transposed = false` (the orientation the current scaffold was built for).
+- In `renderDraftBoard`: `const wantTransposed = isMobileViewport()`. Rebuild the scaffold when
+  `configChanged || !boardTable || !container.contains(boardTable) || wantTransposed !== transposed`.
+  On (re)build, set `transposed = wantTransposed`.
+- State is index-based and orientation-agnostic (`drafted[row][drafter]`, `getPickRow/Drafter`), so
+  flipping orientation never disturbs picks.
+
+### 2. Body rebuild — desktop unchanged; mobile rebuilds each row's tail
+- **Team headers built once**, either way: `buildScaffold` builds
+  `teamHeaderCells: HTMLTableCellElement[]` (index = drafter) from the existing `buildTeamHeader(d)`
+  (label input + method dropdown), and reuses them across picks.
+- **Desktop — unchanged.** `<thead>` = `Round` th + `teamHeaderCells[d]`; `rebuildBoardBody` replaces
+  the whole `<tbody>` per pick (round rows). Exactly as today.
+- **Mobile (transposed).** `<thead>` = corner th + round-number th (`1..nPicks`). One `<tbody>` row
+  per team, whose **first cell is `teamHeaderCells[d]`** (sticky). The mobile branch of
+  `rebuildBoardBody` leaves each row's first cell alone and rebuilds only its trailing pick cells:
+  `for each row: while (row.cells.length > 1) row.deleteCell(-1)`, then append a cell per round from
+  state (`drafted[r][d]` → text + `.drafted`; current `(r,d)` → `.current-pick`; else empty). The
+  team-header cell — and any focus in its label input — is never removed, so the no-churn guarantee
+  holds.
+- `renderDraftBoard` per-render flow is unchanged: (maybe) `buildScaffold` → rebuild pick control →
+  `rebuildBoardBody` → autopilot check. `rebuildBoardBody` just branches on `transposed`.
+
+### 3. `buildTeamHeader` unchanged
+- Same widget (`makeTeamLabelInput` + `makeMethodDropdown`, on `headerListenerController.signal`).
+  Reused verbatim; only its *placement* (thead row vs first column) differs. The mobile header
+  stacking we already added (`.team-header { flex-direction: column }`) fits the narrow first column.
+
+### 4. Round labels / header
+- Desktop round label = first cell of each body row (existing `entry-cell-label`).
+- Mobile: round numbers become the `<thead>` columns (`1..nPicks`); the top-left is an empty corner
+  cell. Reuse `entry-cell-label`-style text.
+
+### 5. Sticky first column (mobile) + auto-scroll
+- Add a `transposed` class to the table (or `.entry-table-scroll`) to scope mobile CSS.
+- `.entry-table.transposed` first-column cells (`th.team-header-cell` and the corner): `position:
+  sticky; left: 0; z-index: 2;` with an **opaque background** (team-header cells already have the
+  `.entry-table th` background) so scrolled pick cells pass underneath, not through.
+- Optional: make the round header row `position: sticky; top: 0` too (frozen header), corner cell
+  sticky on both axes — spreadsheet-style. Mark optional.
+- Auto-scroll: after the mobile body rebuild, if the draft is in progress, bring the current round
+  column into view — keep a reference to the cell tagged `.current-pick` during the rebuild and call
+  `cell.scrollIntoView({ inline: 'nearest', block: 'nearest' })` (or compute `scrollLeft` on
+  `.entry-table-scroll`). Only nudge when the current round actually changed, so it doesn't fight
+  manual scrolling.
+
+### 6. CSS (`styles.css`)
+- New `.entry-table.transposed` rules: sticky first column (+ optional sticky header row), z-index,
+  background. Keep existing `.entry-table` cell styling (borders use `var(--line-grid)`, etc.).
+- Reuse the mobile `.team-header { flex-direction: column }` already added.
+
+### 7. (Optional) live resize flip
+- The app has no resize handling, so v1 flips orientation only on the next natural board render. If we
+  want it to flip live when the viewport crosses 768px, add one debounced `window` resize listener
+  (in `main.ts`/layout) that re-renders the board when `isMobileViewport()` changes. Out of scope for
+  v1 unless requested; called out so the limitation is explicit.
+
+## Edge cases & behaviors to preserve
+- **Editing a team label / changing a method** never resets the board or loses focus, in either
+  orientation (the team-header cell is never removed). This is the key invariant — verify it still
+  holds on mobile; desktop is unchanged.
+- **Autopilot**: fires identically; `refreshPickCells` + auto-scroll follow the advancing pick.
+  `headerListenerController` must not abort mid-autopilot (unchanged).
+- **Undo / Clear**: repaint via `refreshPickCells`; current-pick highlight + auto-scroll update.
+- **n_drafters / n_picks change**: config key changes → scaffold rebuild → grid resized (mobile: more
+  team rows / more round columns); labels + methods restored per index from prefs.
+- **Orientation flip** (load on mobile, or resize/rotate if §7 added): scaffold rebuilds in the new
+  orientation; picks preserved (index-based); a focused label input loses focus on the flip
+  (acceptable, rare).
+- **Sticky column legibility**: team-header cells need an opaque background in both themes; current
+  `.entry-table th` background covers it.
+- **Live platform / auction / season**: out of scope — this spec covers the own-data Draft board
+  only. (Live draft uses a different layout; auction/season boards could get the same treatment in a
+  follow-up.)
+
+## Verification
+- `tsc --noEmit` + `npm run build` clean.
+- **Desktop unchanged**: the desktop render path isn't modified, so board looks/behaves exactly as
+  before — draft picks, autopilot, undo, clear, n_drafters change, label edit (no focus loss / no
+  reset), method change all still work.
+- **Mobile (devtools ≤ 768px / real device)**: board is transposed; team names in the sticky first
+  column stay put while scrolling right through rounds; current pick highlighted; board auto-scrolls
+  to the current round as picks advance; label input + method dropdown usable in the first column;
+  picks survive an orientation flip.
+- Backend suite still green (frontend-only change).
+
+## Out of scope / non-goals
+- Transposing the auction or season boards (possible follow-up).
+- A desktop transpose toggle.
+- Full app-wide resize reflow (only the optional draft-board resize flip in §7).

--- a/frontend/data_entry/draft_board.ts
+++ b/frontend/data_entry/draft_board.ts
@@ -3,7 +3,7 @@
 // Mirrors make_drafting_tab_own_data() in src/tabs/drafting.py.
 
 import { makeCustomSelect } from '../custom_select.js'
-import { readRequiredIntInput } from '../helper_functions.js'
+import { isMobileViewport, readRequiredIntInput } from '../helper_functions.js'
 import { getPlayerResults, getCandidatePlayerResults, getPlayerNamesByGScore, getSessionPhase, getCurrentSeat, setCurrentSeat } from '../app_state.js'
 import { makeDebouncer } from '../api/session.js'
 import { runEvaluate, clearFullTeamResult } from '../api/draft_and_auction_session.js'
@@ -37,8 +37,16 @@ let headerListenerController: AbortController | null = null
 
 let _autopilotRunning = false
 
-const ROUND_W = 32   // px — Round label column
-const TEAM_W  = 50   // px — per-drafter column (min-width floor only; table fills available width)
+// Mobile transposes the board (teams as rows, rounds as columns) with a frozen team-name column.
+// `transposed` is the orientation the current scaffold was built for; the scaffold rebuilds when
+// the viewport crosses the mobile breakpoint and this flips.
+let transposed        = false
+let lastScrolledRound = -1   // mobile auto-scroll: only nudge when the current round changes
+
+const ROUND_W    = 32   // px — Round label column (desktop)
+const TEAM_W     = 50   // px — per-drafter column, desktop (min-width floor; table fills width)
+const TEAMCOL_W  = 90   // px — frozen team-name column (transposed mobile; fits name + method dropdown on one row)
+const ROUNDCOL_W = 64   // px — per-round column (transposed mobile)
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
@@ -61,8 +69,9 @@ export function renderDraftBoard(container: HTMLElement): void {
     if (configChanged) applyDraftConfig(cfg)
 
     // (Re)build the persistent scaffold (pick-control slot + table with its header) on first
-    // render, on a config change, or if the table was detached (container cleared elsewhere).
-    if (configChanged || !boardTable || !container.contains(boardTable)) {
+    // render, on a config change, if the table was detached (container cleared elsewhere), or on
+    // an orientation flip (desktop ⇄ mobile transpose).
+    if (configChanged || !boardTable || !container.contains(boardTable) || isMobileViewport() !== transposed) {
         buildScaffold(container)
     }
 
@@ -88,6 +97,8 @@ export function renderDraftBoard(container: HTMLElement): void {
  *  empty body). Detaches stale header listeners; the body is filled by rebuildBoardBody. */
 function buildScaffold(container: HTMLElement): void {
     container.innerHTML = ''
+    transposed = isMobileViewport()
+    lastScrolledRound = -1
 
     pickControlSlot = document.createElement('div')
     pickControlSlot.className = 'draft-pick-control-slot'
@@ -270,9 +281,15 @@ function buildPickControl(container: HTMLElement): HTMLElement {
 
 // ─── Draft board table ────────────────────────────────────────────────────────
 
-/** Builds the draft board table with its header (Round | per-drafter [label input][method ▾])
- *  and an empty body. The header is built once per scaffold; rebuildBoardBody fills the rows. */
+/** Builds the board table for the current orientation. Header widgets (team label + method
+ *  dropdown) are built once per scaffold; rebuildBoardBody fills the data cells. */
 function buildBoardTable(container: HTMLElement): HTMLTableElement {
+    return transposed ? buildTransposedTable(container) : buildStandardTable(container)
+}
+
+/** Desktop: rounds as rows, teams as columns. Header row = Round | per-team [label input][method ▾];
+ *  empty body filled by rebuildStandardBody. */
+function buildStandardTable(container: HTMLElement): HTMLTableElement {
     const nDrafters = getNDrafters()
 
     const table = document.createElement('table')
@@ -293,7 +310,46 @@ function buildBoardTable(container: HTMLElement): HTMLTableElement {
         hrow.append(th)
     }
 
-    table.createTBody()   // filled by rebuildBoardBody
+    table.createTBody()   // filled by rebuildStandardBody
+    return table
+}
+
+/** Mobile: teams as rows, rounds as columns, with a frozen team-name first column. The header row is
+ *  round numbers; each team row's first cell is the persistent team header (sticky). The trailing
+ *  pick cells are filled/rebuilt by rebuildTransposedBody. */
+function buildTransposedTable(container: HTMLElement): HTMLTableElement {
+    const nDrafters = getNDrafters()
+    const nPicks    = getNPicks()
+
+    const table = document.createElement('table')
+    table.className      = 'entry-table transposed'
+    table.style.width    = '100%'
+    table.style.minWidth = (TEAMCOL_W + nPicks * ROUNDCOL_W) + 'px'
+
+    // Header: [corner] | 1 | 2 | … | nPicks
+    const thead = table.createTHead()
+    const hrow  = thead.insertRow()
+    const corner = document.createElement('th')
+    corner.style.width = TEAMCOL_W + 'px'
+    hrow.append(corner)
+    for (let r = 0; r < nPicks; r++) {
+        const th = document.createElement('th')
+        th.textContent = String(r + 1)
+        th.style.width = ROUNDCOL_W + 'px'
+        hrow.append(th)
+    }
+
+    // One body row per team; first cell = persistent team header (kept across picks by
+    // rebuildTransposedBody, which only rebuilds the trailing pick cells).
+    const tbody = table.createTBody()
+    for (let d = 0; d < nDrafters; d++) {
+        const row = tbody.insertRow()
+        const teamCell = document.createElement('th')
+        teamCell.className = 'team-header-cell'
+        teamCell.style.width = TEAMCOL_W + 'px'
+        teamCell.append(buildTeamHeader(d, container))
+        row.append(teamCell)
+    }
     return table
 }
 
@@ -314,8 +370,14 @@ function buildTeamHeader(drafterIndex: number, container: HTMLElement): HTMLElem
     return cell
 }
 
-/** Replaces the table body with the current picks: rounds × drafters, serpentine highlighting. */
+/** Repaints the picks for the current orientation. */
 function rebuildBoardBody(table: HTMLTableElement): void {
+    if (transposed) rebuildTransposedBody(table)
+    else            rebuildStandardBody(table)
+}
+
+/** Desktop: replace the whole body with rounds × drafters (team headers live in <thead>). */
+function rebuildStandardBody(table: HTMLTableElement): void {
     const nPicks      = getNPicks()
     const nDrafters   = getNDrafters()
     const drafted     = getDrafted()
@@ -345,6 +407,41 @@ function rebuildBoardBody(table: HTMLTableElement): void {
     const oldBody = table.tBodies[0]
     if (oldBody) table.replaceChild(tbody, oldBody)
     else         table.append(tbody)
+}
+
+/** Mobile: per team row, keep the sticky team-header cell (cell 0) and rebuild only the trailing
+ *  pick cells (one per round). Auto-scrolls the current round into view when the round changes. */
+function rebuildTransposedBody(table: HTMLTableElement): void {
+    const nPicks      = getNPicks()
+    const nDrafters   = getNDrafters()
+    const drafted     = getDrafted()
+    const pickRow     = getPickRow()
+    const pickDrafter = getPickDrafter()
+    const tbody       = table.tBodies[0]
+
+    let currentCell: HTMLTableCellElement | null = null
+    for (let d = 0; d < nDrafters; d++) {
+        const row = tbody.rows[d]
+        while (row.cells.length > 1) row.deleteCell(-1)   // keep the sticky team header (cell 0)
+        for (let r = 0; r < nPicks; r++) {
+            const cell   = row.insertCell()
+            const player = drafted[r][d]
+            if (player) {
+                cell.textContent = player
+                cell.classList.add('drafted')
+            } else if (r === pickRow && d === pickDrafter) {
+                cell.classList.add('current-pick')
+                currentCell = cell
+            }
+        }
+    }
+
+    // Follow the draft: bring the current round column into view, but only when the round actually
+    // changes, so it doesn't fight the user's manual horizontal scrolling.
+    if (currentCell && pickRow !== lastScrolledRound) {
+        currentCell.scrollIntoView({ inline: 'nearest', block: 'nearest' })
+        lastScrolledRound = pickRow
+    }
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/frontend/styles/styles.css
+++ b/frontend/styles/styles.css
@@ -1365,6 +1365,57 @@ tr {
     overflow: auto;
 }
 
+/* Transposed draft board (mobile): teams as rows, rounds as columns. Freeze the team-name first
+   column and the round-number header row so they stay visible while scrolling right through rounds.
+   The .transposed class is only added on mobile, so these rules don't need a media query. */
+.entry-table.transposed thead th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+}
+.entry-table.transposed tbody th.team-header-cell {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+}
+.entry-table.transposed thead th:first-child {
+    left: 0;
+    z-index: 3;   /* corner: above both the sticky row and the sticky column */
+}
+/* Honor the column widths so pick cells truncate instead of wrapping long names to many lines. */
+.entry-table.transposed {
+    table-layout: fixed;
+}
+/* In the transposed board the team header sits in the frozen first column, so keep the name and
+   method dropdown on ONE compact row to keep team rows short. (The general mobile rule stacks them,
+   which is right for the column-header layout that auction/season still use, but wrong here.) */
+.entry-table.transposed .team-header {
+    flex-direction: row;
+    gap: 3px;
+}
+.entry-table.transposed .team-label-input {
+    width: auto;
+    font-size: 0.72rem;
+    padding: 0 2px;
+}
+/* Compact every transposed cell: tight padding + line-height, a smaller method trigger, and pick
+   names truncate with an ellipsis rather than wrapping — so team rows stay short. */
+.entry-table.transposed th,
+.entry-table.transposed td {
+    padding: 1px 4px;
+    line-height: 1.2;
+}
+.entry-table.transposed td {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.entry-table.transposed .method-dd-trigger {
+    width: 15px;
+    height: 15px;
+    font-size: 0.62rem;
+}
+
 /* ─── Pick control ───────────────────────────────────────────────────────────── */
 
 .pick-control-label {
@@ -1491,6 +1542,22 @@ tr {
     .categoricalhscore,
     .categoricalRotoHscore {
         padding: 5px 2px;
+    }
+    /* Tabular figures equalise digit widths for column alignment on desktop, but the
+       extra numeral width crowds the narrow mobile stat columns — use proportional
+       figures here so the values stay compact. */
+    #hscoretable,
+    .panel-table {
+        font-variant-numeric: normal;
+    }
+    /* Stack each board header so the team name sits on its own line above the method
+       dropdown — keeps the column narrow to save horizontal space. */
+    .team-header {
+        flex-direction: column;
+        gap: 2px;
+    }
+    .team-header .team-label-input {
+        width: 100%;
     }
     /* Tighten vertical spacing between the candidate-panel sections so there's
        not a big empty band between the auction board and the candidate table. */


### PR DESCRIPTION
On mobile the draft board renders transposed — teams as rows, rounds as columns — with a frozen team-name first column (sticky) and a sticky round-number header, so names stay visible while scrolling right through rounds; the current round auto-scrolls into view as picks advance. Desktop is untouched (separate buildStandardTable/rebuildStandardBody paths); the transposed body keeps each row's persistent team-header cell and rebuilds only the trailing pick cells, preserving the no-focus-loss guarantee. Transposed cells are compacted (tight padding, smaller method trigger, table-layout: fixed with ellipsis) so team rows stay short.

Also: disable tabular-nums on mobile (proportional figures stop crowding narrow stat columns) and stack auction/season column headers (name above dropdown) on mobile. Draft board only — auction/season fill differently.